### PR TITLE
Automatically import flow types

### DIFF
--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -188,15 +188,15 @@ function validateObjectTypeAnnotation(
   propName,
   propType
 ) {
-  const propTypeProperty =
-    propType.properties.filter(property =>
+  const propTypeProperty = propType.properties.filter(
+    property =>
       // HACK: https://github.com/babel/babel-eslint/issues/307
-        context.getSourceCode().getFirstToken(property).value === propName
-    )[0];
+      context.getSourceCode().getFirstToken(property).value === propName
+  )[0];
 
   let atleastOnePropertyExists = !!propType.properties[0];
 
-  if(!propTypeProperty) {
+  if (!propTypeProperty) {
     context.report({
       message:
         'Component property `{{prop}}` expects to use the generated ' +
@@ -205,15 +205,16 @@ function validateObjectTypeAnnotation(
         prop: propName,
         type
       },
-      fix: fixer => atleastOnePropertyExists
-        ? fixer.insertTextBefore(
-            propType.properties[0],
-            `${propName}: ${type}, `
-          )
-        : fixer.replaceText(propType, `{${propName}: ${type}}`),
+      fix: fixer =>
+        atleastOnePropertyExists
+          ? fixer.insertTextBefore(
+              propType.properties[0],
+              `${propName}: ${type}, `
+            )
+          : fixer.replaceText(propType, `{${propName}: ${type}}`),
       loc: Component
     });
-  } else if(
+  } else if (
     propTypeProperty.value.type !== 'GenericTypeAnnotation' ||
     propTypeProperty.value.id.name !== type
   ) {
@@ -479,15 +480,18 @@ module.exports.rules = {
         ClassDeclaration(node) {
           const componentName = node.id.name;
           componentMap[componentName] = {
-            Component: node.id,
+            Component: node.id
           };
-          node.body.body.filter(child =>
-            child.type === 'ClassProperty' &&
-            child.key.name === 'props' &&
-            child.typeAnnotation
-          ).forEach(child => {
-            componentMap[componentName].propType = child.typeAnnotation;
-          })
+          node.body.body
+            .filter(
+              child =>
+                child.type === 'ClassProperty' &&
+                child.key.name === 'props' &&
+                child.typeAnnotation
+            )
+            .forEach(child => {
+              componentMap[componentName].propType = child.typeAnnotation;
+            });
         },
         TaggedTemplateExpression(node) {
           const ast = getGraphQLAST(node);
@@ -510,15 +514,15 @@ module.exports.rules = {
           expectedTypes.forEach(type => {
             const componentName = type.split('_')[0];
             const propName = type.split('_')[1];
-            if(!componentName || ! propName || !componentMap[componentName]) {
+            if (!componentName || !propName || !componentMap[componentName]) {
               // incorrect name, covered by graphql-naming/CallExpression
               return;
             }
             const {Component, propType} = componentMap[componentName];
-            if(propType) {
+            if (propType) {
               // There exists a prop typeAnnotation. Let's look at how it's
               // structured
-              switch(propType.typeAnnotation.type) {
+              switch (propType.typeAnnotation.type) {
                 case 'ObjectTypeAnnotation':
                   validateObjectTypeAnnotation(
                     context,
@@ -546,7 +550,6 @@ module.exports.rules = {
                     typeAliasMap[alias]
                   );
                   break;
-
               }
             } else {
               context.report({
@@ -559,20 +562,22 @@ module.exports.rules = {
                 },
                 fix: fixer => {
                   const classBodyStart = Component.parent.body.body[0];
-                  if(!classBodyStart) {
+                  if (!classBodyStart) {
                     // HACK: There's nothing in the body. Let's not do anything
                     // When something is added to the body, we'll have a fix
                     return;
                   }
-                  const aliasWhitespace =
-                    ' '.repeat(Component.parent.loc.start.column);
-                  const propsWhitespace =
-                    ' '.repeat(classBodyStart.loc.start.column);
+                  const aliasWhitespace = ' '.repeat(
+                    Component.parent.loc.start.column
+                  );
+                  const propsWhitespace = ' '.repeat(
+                    classBodyStart.loc.start.column
+                  );
                   return [
                     fixer.insertTextBefore(
                       Component.parent,
                       `type Props = {${propName}: ` +
-                      `${type}};\n\n${aliasWhitespace}`
+                        `${type}};\n\n${aliasWhitespace}`
                     ),
                     fixer.insertTextBefore(
                       classBodyStart,

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -124,10 +124,11 @@ function getOptions(optionValue) {
 
 function genImportFixRange(type, imports, requires) {
   const typeImports = imports.filter(node => node.importKind === 'type');
-  const alreadyHasImport = typeImports
-    .some(node =>
-      node.specifiers.some(specifier => (specifier.imported || specifier.local).name === type)
-    );
+  const alreadyHasImport = typeImports.some(node =>
+    node.specifiers.some(
+      specifier => (specifier.imported || specifier.local).name === type
+    )
+  );
 
   if (alreadyHasImport) {
     return null;
@@ -137,21 +138,24 @@ function genImportFixRange(type, imports, requires) {
     return (node.specifiers[0].local || node.specifiers[0].imported).name;
   }
 
-  if(typeImports.length > 0) {
+  if (typeImports.length > 0) {
     let precedingImportIndex = 0;
-    while(typeImports[precedingImportIndex+1] && getTypeImportName(typeImports[precedingImportIndex+1]) < type){
+    while (
+      typeImports[precedingImportIndex + 1] &&
+      getTypeImportName(typeImports[precedingImportIndex + 1]) < type
+    ) {
       precedingImportIndex++;
     }
 
     return typeImports[precedingImportIndex].range;
   }
 
-  if(imports.length > 0) {
-    return imports[imports.length-1].range;
+  if (imports.length > 0) {
+    return imports[imports.length - 1].range;
   }
 
-  if(requires.length > 0) {
-    return requires[requires.length-1].range;
+  if (requires.length > 0) {
+    return requires[requires.length - 1].range;
   }
 
   // start of file
@@ -159,9 +163,9 @@ function genImportFixRange(type, imports, requires) {
 }
 
 function genImportFixer(fixer, importFixRange, type, haste, whitespace) {
-  if(!importFixRange) {
+  if (!importFixRange) {
     // HACK: insert nothing
-    return fixer.replaceTextRange([0, 0],'');
+    return fixer.replaceTextRange([0, 0], '');
   }
   if (haste) {
     return fixer.insertTextAfterRange(

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -407,5 +407,19 @@ module.exports.rules = {
         }
       };
     }
+  },
+  'generated-flow-types': {
+    meta: {
+      fixable: 'code',
+      docs: {
+        description: 'Validates usage of RelayModern generated flow types'
+      }
+    },
+    create(context) {
+      if (!shouldLint(context)) {
+        return {};
+      }
+      return {};
+    }
   }
 };

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -150,6 +150,10 @@ function genImportFixRange(type, imports, requires) {
     return imports[imports.length-1].range;
   }
 
+  if(requires.length > 0) {
+    return requires[requires.length-1].range;
+  }
+
   // start of file
   return [0, 0];
 }
@@ -162,7 +166,7 @@ function genImportFixer(fixer, importFixRange, type, haste, whitespace) {
   if (haste) {
     return fixer.insertTextAfterRange(
       importFixRange,
-      `${whitespace}import type {${type}} from './${type}.graphql'`
+      `\n${whitespace}import type {${type}} from '${type}.graphql'`
     );
   } else {
     return fixer.insertTextAfterRange(

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -276,7 +276,7 @@ function validateObjectTypeAnnotation(
     context.report({
       message:
         'ADVICE: Component property `{{prop}}` expects to use the generated ' +
-          '`{{type}}` flow type.',
+          '`{{type}}` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.',
       data: {
         prop: propName,
         type
@@ -315,7 +315,7 @@ function validateObjectTypeAnnotation(
     context.report({
       message:
         'ADVICE: Component property `{{prop}}` expects to use the generated ' +
-          '`{{type}}` flow type.',
+          '`{{type}}` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.',
       data: {
         prop: propName,
         type
@@ -697,7 +697,7 @@ module.exports.rules = {
               context.report({
                 message:
                   'ADVICE: Component property `{{prop}}` expects to use the ' +
-                    'generated `{{type}}` flow type.',
+                    'generated `{{type}}` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.',
                 data: {
                   prop: propName,
                   type

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -181,7 +181,13 @@ function validateTemplate(context, taggedTemplateExpression, keyName) {
   });
 }
 
-function validateObjectTypeAnnotation(context, Component, type, propName, propType) {
+function validateObjectTypeAnnotation(
+  context,
+  Component,
+  type,
+  propName,
+  propType
+) {
   const propTypeProperty =
     propType.typeAnnotation.properties.filter(property =>
       // HACK: https://github.com/babel/babel-eslint/issues/307
@@ -202,7 +208,10 @@ function validateObjectTypeAnnotation(context, Component, type, propName, propTy
         type
       },
       fix: fixer => atleastOnePropertyExists
-        ? fixer.insertTextBefore(propType.typeAnnotation.properties[0], `${propName}: ${type}, `)
+        ? fixer.insertTextBefore(
+            propType.typeAnnotation.properties[0],
+            `${propName}: ${type}, `
+          )
         : fixer.replaceText(propType.typeAnnotation, `{${propName}: ${type}}`),
       loc: Component
     });
@@ -527,8 +536,8 @@ module.exports.rules = {
               // the typeAnnotation for props
               context.report({
                 message:
-                  'Component property `{{prop}}` expects to use the generated ' +
-                    '`{{type}}` flow type.',
+                  'Component property `{{prop}}` expects to use the ' +
+                    'generated `{{type}}` flow type.',
                 data: {
                   prop: propName,
                   type

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -275,7 +275,7 @@ function validateObjectTypeAnnotation(
   if (!propTypeProperty) {
     context.report({
       message:
-        'Component property `{{prop}}` expects to use the generated ' +
+        'ADVICE: Component property `{{prop}}` expects to use the generated ' +
           '`{{type}}` flow type.',
       data: {
         prop: propName,
@@ -314,7 +314,7 @@ function validateObjectTypeAnnotation(
   ) {
     context.report({
       message:
-        'Component property `{{prop}}` expects to use the generated ' +
+        'ADVICE: Component property `{{prop}}` expects to use the generated ' +
           '`{{type}}` flow type.',
       data: {
         prop: propName,
@@ -696,7 +696,7 @@ module.exports.rules = {
             } else {
               context.report({
                 message:
-                  'Component property `{{prop}}` expects to use the ' +
+                  'ADVICE: Component property `{{prop}}` expects to use the ' +
                     'generated `{{type}}` flow type.',
                 data: {
                   prop: propName,

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -138,13 +138,16 @@ function genImportFixRange(type, imports, requires) {
   }
 
   if(typeImports.length > 0) {
-    // const sortedImports = typeImports.filter(node => node.specifiers[0]).sort(compareImports);
     let precedingImportIndex = 0;
     while(typeImports[precedingImportIndex+1] && getTypeImportName(typeImports[precedingImportIndex+1]) < type){
       precedingImportIndex++;
     }
 
     return typeImports[precedingImportIndex].range;
+  }
+
+  if(imports.length > 0) {
+    return imports[imports.length-1].range;
   }
 
   // start of file

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -419,7 +419,26 @@ module.exports.rules = {
       if (!shouldLint(context)) {
         return {};
       }
-      return {};
+      return {
+        TaggedTemplateExpression(node) {
+          const ast = getGraphQLAST(node);
+          if (!ast) {
+            return;
+          }
+
+          const moduleName = getModuleName(context.getFilename());
+          ast.definitions.forEach(def => {
+            if (!def.name) {
+              // no name, covered by graphql-naming/TaggedTemplateExpression
+              return;
+            }
+            const definitionName = def.name.value;
+            if (def.kind === 'FragmentDefinition') {
+              console.log(def.name.value);
+            }
+          });
+        }
+      };
     }
   }
 };

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -433,8 +433,22 @@ module.exports.rules = {
               return;
             }
             const definitionName = def.name.value;
+            const propName = definitionName.split('_')[1];
+            if(!propName) {
+              return;
+              // invalid fragment name, covered by graphql-naming/CallExpression
+            }
             if (def.kind === 'FragmentDefinition') {
-              console.log(def.name.value);
+              context.report({
+                message:
+                  'Component property `{{prop}}` expects to use the generated ' +
+                    '`{{type}}` flow type.',
+                data: {
+                  prop: propName,
+                  type: definitionName
+                },
+                loc: getLoc(context, node, def.name)
+              });
             }
           });
         }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "3.19.0",
+    "eslint": "^3.19.0",
     "mocha": "^3.4.2",
     "prettier": "^1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "^3.19.0",
+    "eslint": "^4.1.0",
     "mocha": "^3.4.2",
     "prettier": "^1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "^4.1.0",
+    "eslint": "3.19.0",
     "mocha": "^3.4.2",
     "prettier": "^1.4.4"
   }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "graphql": "^0.10.1"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.3",
     "eslint": "^3.19.0",
     "mocha": "^3.4.2",
     "prettier": "^1.4.4"

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,10 @@ const path = require('path');
 const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
-const ruleTester = new RuleTester({parser: 'babel-eslint', parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}});
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+});
 
 const valid = [
   {code: 'hello();'},
@@ -579,6 +582,6 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
               '`MyComponent_user` flow type.'
         }
       ]
-    },
+    }
   ]
 });

--- a/test/test.js
+++ b/test/test.js
@@ -282,7 +282,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -321,7 +321,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -360,7 +360,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -399,7 +399,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -442,7 +442,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -485,7 +485,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -528,7 +528,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -571,7 +571,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -610,7 +610,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -650,7 +650,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -692,7 +692,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -737,7 +737,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -782,7 +782,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -827,7 +827,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -872,7 +872,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -925,7 +925,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     },
@@ -970,7 +970,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
-              '`MyComponent_user` flow type.'
+              '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     }

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ const path = require('path');
 const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
-const ruleTester = new RuleTester({parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}});
+const ruleTester = new RuleTester({parser: 'babel-eslint', parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}});
 
 const valid = [
   {code: 'hello();'},
@@ -206,6 +206,21 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {code: 'graphql`query {{{`'},
     {
       code: `
+        class MyComponent extends React.Component {
+          props: {user: MyComponent_user};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
         type Props = {
           user: MyComponent_user,
         }
@@ -229,6 +244,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       filename: 'MyComponent.jsx',
       code: `
         class MyComponent extends React.Component {
+          props: {};
+
           render() {
             return <div />;
           }
@@ -239,9 +256,309 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
-        type Props = {
-          user: MyComponent_user,
+        class MyComponent extends React.Component {
+          props: {user: MyComponent_user};
+
+          render() {
+            return <div />;
+          }
         }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        class MyComponent extends React.Component {
+          props: {somethingElse: number};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        class MyComponent extends React.Component {
+          props: {user: MyComponent_user, somethingElse: number};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        class MyComponent extends React.Component {
+          props: {user: number};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        class MyComponent extends React.Component {
+          props: {user: MyComponent_user};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        class MyComponent extends React.Component {
+          props: {user: Random_user};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        class MyComponent extends React.Component {
+          props: {user: MyComponent_user};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        type Props = {};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        type Props = {somethingElse: number};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        type Props = {user: MyComponent_user, somethingElse: number};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        type Props = {user: number};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        type Props = {user: Random_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        type Props = {user: MyComponent_user};
 
         class MyComponent extends React.Component {
           props: Props;

--- a/test/test.js
+++ b/test/test.js
@@ -203,7 +203,26 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
   valid: [
     ...valid,
     // syntax error, covered by `graphql-syntax`
-    {code: 'graphql`query {{{`'}
+    {code: 'graphql`query {{{`'},
+    {
+      code: `
+        type Props = {
+          user: MyComponent_user,
+        }
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    }
   ],
   invalid: [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -597,6 +597,44 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       filename: 'MyComponent.jsx',
       code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      options: [{haste: true}],
+      output: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
 
         class MyComponent extends React.Component {
@@ -637,7 +675,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       filename: 'MyComponent.jsx',
       code: `
-        import type aaa from 'abc'
+        import type aaa from 'aaa'
         import type zzz from 'zzz'
 
         class MyComponent extends React.Component {
@@ -651,7 +689,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
-        import type aaa from 'abc'
+        import type aaa from 'aaa'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         import type zzz from 'zzz'
 
@@ -680,7 +718,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       filename: 'MyComponent.jsx',
       code: `
-        import type {aaa} from 'abc'
+        import type {aaa} from 'aaa'
         import type zzz from 'zzz'
 
         class MyComponent extends React.Component {
@@ -694,7 +732,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
-        import type {aaa} from 'abc'
+        import type {aaa} from 'aaa'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         import type zzz from 'zzz'
 
@@ -723,7 +761,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       filename: 'MyComponent.jsx',
       code: `
-        import {aaa} from 'abc'
+        import {aaa} from 'aaa'
         import zzz from 'zzz'
 
         class MyComponent extends React.Component {
@@ -737,7 +775,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
-        import {aaa} from 'abc'
+        import {aaa} from 'aaa'
         import zzz from 'zzz'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
 
@@ -762,6 +800,143 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
               '`MyComponent_user` flow type.'
         }
       ]
-    }
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        const aaa = require('aaa')
+        const zzz = require('zzz')
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        const aaa = require('aaa')
+        const zzz = require('zzz')
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        const aaa = require('aaa')
+
+        import zzz from 'zzz'
+
+        import type ccc from 'ccc'
+        import type {xxx} from 'xxx'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        const aaa = require('aaa')
+
+        import zzz from 'zzz'
+
+        import type ccc from 'ccc'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type {xxx} from 'xxx'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
   ]
 });

--- a/test/test.js
+++ b/test/test.js
@@ -593,6 +593,89 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
               '`MyComponent_user` flow type.'
         }
       ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import type aaa from 'abc'
+        import type zzz from 'abc'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        import type aaa from 'abc'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type zzz from 'abc'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
     }
   ]
 });

--- a/test/test.js
+++ b/test/test.js
@@ -638,7 +638,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       filename: 'MyComponent.jsx',
       code: `
         import type aaa from 'abc'
-        import type zzz from 'abc'
+        import type zzz from 'zzz'
 
         class MyComponent extends React.Component {
           render() {
@@ -653,7 +653,93 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       output: `
         import type aaa from 'abc'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
-        import type zzz from 'abc'
+        import type zzz from 'zzz'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import type {aaa} from 'abc'
+        import type zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        import type {aaa} from 'abc'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type zzz from 'zzz'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import {aaa} from 'abc'
+        import zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: `
+        import {aaa} from 'abc'
+        import zzz from 'zzz'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
 
         type Props = {user: MyComponent_user};
 

--- a/test/test.js
+++ b/test/test.js
@@ -258,8 +258,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'React components with fragments must use the ' +
-              'generated `<ModuleName>_<propName>` flow type.'
+            'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` flow type.'
         }
       ]
     },

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,8 @@ const path = require('path');
 const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
+const HAS_ESLINT_BEEN_UPGRADED_YET = false;
+
 const ruleTester = new RuleTester({
   parser: 'babel-eslint',
   parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
@@ -260,7 +262,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
@@ -273,7 +276,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -297,7 +301,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user, somethingElse: number};
@@ -310,7 +315,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -334,7 +340,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
@@ -347,7 +354,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -371,7 +379,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
@@ -384,7 +393,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -410,7 +420,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
@@ -425,7 +436,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -451,7 +463,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user, somethingElse: number};
 
@@ -466,7 +479,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -492,7 +506,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
@@ -507,7 +522,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -533,7 +549,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
@@ -548,7 +565,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -570,7 +588,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
@@ -585,7 +604,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -608,7 +628,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       options: [{haste: true}],
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from 'MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
@@ -623,7 +644,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -647,7 +669,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
 
         type Props = {user: MyComponent_user};
@@ -663,7 +686,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -688,7 +712,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type aaa from 'aaa'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         import type zzz from 'zzz'
@@ -706,7 +731,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -731,7 +757,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import type {aaa} from 'aaa'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         import type zzz from 'zzz'
@@ -749,7 +776,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -774,7 +802,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import {aaa} from 'aaa'
         import zzz from 'zzz'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
@@ -792,7 +821,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -817,7 +847,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         const aaa = require('aaa')
         const zzz = require('zzz')
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
@@ -835,7 +866,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -864,7 +896,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         const aaa = require('aaa')
 
         import zzz from 'zzz'
@@ -886,7 +919,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:
@@ -911,7 +945,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `,
-      output: `
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
         import {aaa} from 'aaa'
         import zzz from 'zzz'
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
@@ -929,7 +964,8 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         createFragmentContainer(MyComponent, {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
-      `,
+      `
+        : null,
       errors: [
         {
           message:

--- a/test/test.js
+++ b/test/test.js
@@ -281,7 +281,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -320,7 +320,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -359,7 +359,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -398,7 +398,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -441,7 +441,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -484,7 +484,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -527,7 +527,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -570,7 +570,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -609,7 +609,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -649,7 +649,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -691,7 +691,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -736,7 +736,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -781,7 +781,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -826,7 +826,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -871,7 +871,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -924,7 +924,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]
@@ -969,7 +969,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       errors: [
         {
           message:
-            'Component property `user` expects to use the generated ' +
+            'ADVICE: Component property `user` expects to use the generated ' +
               '`MyComponent_user` flow type.'
         }
       ]

--- a/test/test.js
+++ b/test/test.js
@@ -209,6 +209,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {code: 'graphql`query {{{`'},
     {
       code: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
 
@@ -224,6 +225,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     },
     {
       code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
         type Props = {
           user: MyComponent_user,
         }
@@ -259,6 +261,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
 
@@ -295,6 +298,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user, somethingElse: number};
 
@@ -331,6 +335,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
 
@@ -367,6 +372,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         class MyComponent extends React.Component {
           props: {user: MyComponent_user};
 
@@ -405,6 +411,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
         class MyComponent extends React.Component {
@@ -445,6 +452,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user, somethingElse: number};
 
         class MyComponent extends React.Component {
@@ -485,6 +493,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
         class MyComponent extends React.Component {
@@ -525,6 +534,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
         class MyComponent extends React.Component {
@@ -561,6 +571,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `,
       output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
         type Props = {user: MyComponent_user};
 
         class MyComponent extends React.Component {

--- a/test/test.js
+++ b/test/test.js
@@ -937,6 +937,6 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
               '`MyComponent_user` flow type.'
         }
       ]
-    },
+    }
   ]
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,13 +59,62 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-babel-code-frame@^6.16.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+babel-eslint@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-traverse@^6.23.1:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.23.0, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babylon@^6.17.0, babylon@^6.17.2:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -142,6 +191,10 @@ concat-stream@^1.5.2:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+core-js@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -152,7 +205,7 @@ d@1:
   dependencies:
     es5-ext "^0.10.9"
 
-debug@2.6.0, debug@^2.1.1:
+debug@2.6.0, debug@^2.1.1, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
@@ -297,6 +350,10 @@ espree@^3.4.0:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
 
+esprima-fb@^15001.1001.0-dev-harmony-fb:
+  version "15001.1001.0-dev-harmony-fb"
+  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
+
 esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
@@ -389,7 +446,7 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -472,6 +529,12 @@ inquirer@^0.12.0:
 interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
+
+invariant@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -609,9 +672,15 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
 
 minimatch@^3.0.2:
   version "3.0.4"
@@ -762,6 +831,10 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+regenerator-runtime@^0.10.0:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
 require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -885,6 +958,10 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+to-fast-properties@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
 tryit@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -303,7 +303,7 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@3.19.0:
+eslint@^3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,9 +27,9 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -59,7 +59,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -155,11 +155,11 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -168,10 +168,6 @@ cli-width@^2.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 commander@2.9.0:
   version "2.9.0"
@@ -183,7 +179,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
+concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -199,17 +195,17 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  dependencies:
-    es5-ext "^0.10.9"
-
-debug@2.6.0, debug@^2.1.1, debug@^2.2.0:
+debug@2.6.0, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
+
+debug@^2.6.8:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
+  dependencies:
+    ms "2.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -238,121 +234,61 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.23"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
-  dependencies:
-    es6-iterator "2"
-    es6-symbol "~3.1"
-
-es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-symbol "^3.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
-
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-scope@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.19.0:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+eslint@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.1.0.tgz#bbb55a28220ee08b69da9554d45a6b2ebfd7d913"
   dependencies:
-    babel-code-frame "^6.16.0"
+    babel-code-frame "^6.22.0"
     chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
+    concat-stream "^1.6.0"
+    debug "^2.6.8"
     doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
+    eslint-scope "^3.7.1"
+    espree "^3.4.3"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
+    inquirer "^3.0.6"
+    is-my-json-valid "^2.16.0"
     is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    js-yaml "^3.8.4"
+    json-stable-stringify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^4.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
     strip-json-comments "~2.0.1"
-    table "^3.7.8"
+    table "^4.0.1"
     text-table "~0.2.0"
-    user-home "^2.0.0"
 
-espree@^3.4.0:
+espree@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
     acorn "^5.0.1"
     acorn-jsx "^3.0.0"
-
-esprima-fb@^15001.1001.0-dev-harmony-fb:
-  version "15001.1001.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
 
 esprima@^3.1.1:
   version "3.1.3"
@@ -383,27 +319,23 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+external-editor@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
   dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
+    tmp "^0.0.31"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -435,7 +367,7 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -446,7 +378,18 @@ glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.14.0:
+glob@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^9.0.0, globals@^9.17.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -489,7 +432,11 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-ignore@^3.2.0:
+iconv-lite@^0.4.17:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -508,27 +455,24 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.1.1.tgz#87621c4fba4072f48a8dd71c9f9df6f100b2d534"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
+    ansi-escapes "^2.0.0"
     chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
-
-interpret@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -536,17 +480,11 @@ invariant@^2.2.0:
   dependencies:
     loose-envify "^1.0.0"
 
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-my-json-valid@^2.10.0:
+is-my-json-valid@^2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
@@ -571,6 +509,10 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -593,14 +535,18 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.5.1:
+js-yaml@^3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+jschardet@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.4.2.tgz#2aa107f142af4121d145659d44f50830961e699a"
+
+json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -672,7 +618,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -682,7 +628,11 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-minimatch@^3.0.2:
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -692,7 +642,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -718,19 +668,19 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -740,9 +690,11 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -755,21 +707,17 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-homedir@^1.0.0:
+os-tmpdir@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
-
-path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -785,9 +733,9 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -801,9 +749,9 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
 readable-stream@^2.2.2:
   version "2.2.10"
@@ -817,25 +765,11 @@ readable-stream@^2.2.2:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
-
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -846,18 +780,12 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-resolve@^1.1.6:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
   dependencies:
-    path-parse "^1.0.5"
-
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
 
 rimraf@^2.2.8:
   version "2.6.1"
@@ -865,27 +793,29 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.0.5"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 safe-buffer@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
+signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -894,14 +824,6 @@ slice-ansi@0.0.4:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
 
 string-width@^2.0.0:
   version "2.0.0"
@@ -922,10 +844,6 @@ strip-ansi@^3.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-strip-bom@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
-
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -940,9 +858,9 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+table@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
   dependencies:
     ajv "^4.7.0"
     ajv-keywords "^1.0.0"
@@ -958,6 +876,12 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
 
 to-fast-properties@^1.0.1:
   version "1.0.3"
@@ -976,12 +900,6 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,9 +27,9 @@ ajv@^4.7.0:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ansi-escapes@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -59,7 +59,7 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -155,11 +155,11 @@ circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+cli-cursor@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
-    restore-cursor "^2.0.0"
+    restore-cursor "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -168,6 +168,10 @@ cli-width@^2.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 commander@2.9.0:
   version "2.9.0"
@@ -179,7 +183,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.6.0:
+concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -195,17 +199,17 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-debug@2.6.0, debug@^2.2.0:
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
+debug@2.6.0, debug@^2.1.1, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
-
-debug@^2.6.8:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -234,56 +238,112 @@ doctrine@^2.0.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.23"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-eslint-scope@^3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
   dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.1.0.tgz#bbb55a28220ee08b69da9554d45a6b2ebfd7d913"
+eslint@3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
-    babel-code-frame "^6.22.0"
+    babel-code-frame "^6.16.0"
     chalk "^1.1.3"
-    concat-stream "^1.6.0"
-    debug "^2.6.8"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
     doctrine "^2.0.0"
-    eslint-scope "^3.7.1"
-    espree "^3.4.3"
+    escope "^3.6.0"
+    espree "^3.4.0"
     esquery "^1.0.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.1.2"
-    globals "^9.17.0"
-    ignore "^3.3.3"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
     imurmurhash "^0.1.4"
-    inquirer "^3.0.6"
-    is-my-json-valid "^2.16.0"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
     is-resolvable "^1.0.0"
-    js-yaml "^3.8.4"
-    json-stable-stringify "^1.0.1"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
     levn "^0.3.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.2"
-    mkdirp "^0.5.1"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
-    pluralize "^4.0.0"
-    progress "^2.0.0"
-    require-uncached "^1.0.3"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "^3.7.8"
     text-table "~0.2.0"
+    user-home "^2.0.0"
 
-espree@^3.4.3:
+espree@^3.4.0:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
@@ -319,23 +379,27 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-external-editor@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   dependencies:
-    iconv-lite "^0.4.17"
-    jschardet "^1.4.2"
-    tmp "^0.0.31"
+    d "1"
+    es5-ext "~0.10.14"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+figures@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
     escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -367,7 +431,7 @@ generate-object-property@^1.1.0:
   dependencies:
     is-property "^1.0.0"
 
-glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -378,18 +442,7 @@ glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-globals@^9.0.0, globals@^9.17.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
@@ -432,11 +485,7 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
-iconv-lite@^0.4.17:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
-
-ignore@^3.3.3:
+ignore@^3.2.0:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -455,24 +504,27 @@ inherits@2, inherits@^2.0.3, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^3.0.6:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.1.1.tgz#87621c4fba4072f48a8dd71c9f9df6f100b2d534"
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
   dependencies:
-    ansi-escapes "^2.0.0"
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
     chalk "^1.0.0"
-    cli-cursor "^2.1.0"
+    cli-cursor "^1.0.1"
     cli-width "^2.0.0"
-    external-editor "^2.0.4"
-    figures "^2.0.0"
+    figures "^1.3.5"
     lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx-lite "^4.0.8"
-    rx-lite-aggregates "^4.0.8"
-    string-width "^2.0.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
     strip-ansi "^3.0.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
 invariant@^2.2.0:
   version "2.2.2"
@@ -480,11 +532,17 @@ invariant@^2.2.0:
   dependencies:
     loose-envify "^1.0.0"
 
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  dependencies:
+    number-is-nan "^1.0.0"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-my-json-valid@^2.16.0:
+is-my-json-valid@^2.10.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
   dependencies:
@@ -509,10 +567,6 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -535,18 +589,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.8.4:
+js-yaml@^3.5.1:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
-jschardet@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.4.2.tgz#2aa107f142af4121d145659d44f50830961e699a"
-
-json-stable-stringify@^1.0.1:
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -618,7 +668,7 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -628,11 +678,7 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
-mimic-fn@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
-
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -642,7 +688,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -668,19 +714,19 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
-
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-object-assign@^4.0.1:
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -690,11 +736,9 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  dependencies:
-    mimic-fn "^1.0.0"
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 optionator@^0.8.2:
   version "0.8.2"
@@ -707,17 +751,21 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-os-tmpdir@~1.0.1:
+os-homedir@^1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
 
 pify@^2.0.0:
   version "2.3.0"
@@ -733,9 +781,9 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-pluralize@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -749,9 +797,9 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-progress@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 readable-stream@^2.2.2:
   version "2.2.10"
@@ -765,11 +813,25 @@ readable-stream@^2.2.2:
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
-require-uncached@^1.0.3:
+require-uncached@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -780,12 +842,18 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+resolve@^1.1.6:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
+    path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
 
 rimraf@^2.2.8:
   version "2.6.1"
@@ -793,29 +861,27 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.0.5"
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
   dependencies:
-    is-promise "^2.1.0"
+    once "^1.3.0"
 
-rx-lite-aggregates@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
-  dependencies:
-    rx-lite "*"
-
-rx-lite@*, rx-lite@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
 safe-buffer@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
-signal-exit@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+shelljs@^0.7.5:
+  version "0.7.8"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -824,6 +890,14 @@ slice-ansi@0.0.4:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
 
 string-width@^2.0.0:
   version "2.0.0"
@@ -844,6 +918,10 @@ strip-ansi@^3.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
@@ -858,9 +936,9 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-table@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-4.0.1.tgz#a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
   dependencies:
     ajv "^4.7.0"
     ajv-keywords "^1.0.0"
@@ -876,12 +954,6 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-tmp@^0.0.31:
-  version "0.0.31"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
-  dependencies:
-    os-tmpdir "~1.0.1"
 
 to-fast-properties@^1.0.1:
   version "1.0.3"
@@ -900,6 +972,12 @@ type-check@~0.3.2:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Closes #2 

This adds a new lint rule that checks for usage of generated flow types, and automatically adds them if it doesn't. I've added 11 test cases as well.

As a side note, I had to bring in `babel-eslint` (to parse flow) and upgrade to eslint version ^4.1.0 for this feature: https://github.com/eslint/eslint/pull/8101.

> I chose `babel-eslint` over `esprima-fb` because the latter broke some old test cases as `esprima` uses different naming conventions than the default `espree` parser)
