### PR TITLE
Support type aliases

### DIFF
--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -681,6 +681,7 @@ module.exports.rules = {
             }
             const {Component, propType} = componentMap[componentName];
 
+            // resolve local type alias
             const importedPropType = imports.reduce((acc, node) => {
               if (node.specifiers) {
                 const typeSpecifier = node.specifiers.find(specifier => {

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -319,7 +319,15 @@ function validateObjectTypeAnnotation(
         : null,
       loc: Component.loc
     });
-  } else if (
+    return;
+  }
+  if (
+    propTypeProperty.value.type === 'NullableTypeAnnotation' &&
+    propTypeProperty.value.typeAnnotation.id.name === type
+  ) {
+    return;
+  }
+  if (
     propTypeProperty.value.type !== 'GenericTypeAnnotation' ||
     propTypeProperty.value.id.name !== type
   ) {

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -682,21 +682,25 @@ module.exports.rules = {
             const {Component, propType} = componentMap[componentName];
 
             const importedPropType = imports.reduce((acc, node) => {
-              if(node.specifiers){
+              if (node.specifiers) {
                 const typeSpecifier = node.specifiers.find(specifier => {
-                  if(specifier.type !== 'ImportSpecifier'){
+                  if (specifier.type !== 'ImportSpecifier') {
                     return false;
                   }
-                  return specifier.imported.name === type
+                  return specifier.imported.name === type;
                 });
-                if(typeSpecifier){
+                if (typeSpecifier) {
                   return typeSpecifier.local.name;
                 }
               }
               return acc;
             }, type);
 
-            const importFixRange = genImportFixRange(importedPropType, imports, requires);
+            const importFixRange = genImportFixRange(
+              importedPropType,
+              imports,
+              requires
+            );
 
             if (propType) {
               // There exists a prop typeAnnotation. Let's look at how it's

--- a/test/test.js
+++ b/test/test.js
@@ -227,6 +227,22 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     },
     {
       code: `
+        import type {MyComponent_user as User} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component {
+          props: {user: User};
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
         import type {MyComponent_user} from 'MyComponent_user.graphql'
         type Props = {
           user: MyComponent_user,
@@ -1089,6 +1105,48 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           message:
             'ADVICE: Component property `user` expects to use the generated ' +
             '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        import type {MyComponent_user as User} from 'aaa'
+
+        class MyComponent extends React.Component {
+          props: { user: MyComponent_user }
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      output: HAS_ESLINT_BEEN_UPGRADED_YET
+        ? `
+        import type {MyComponent_user as User} from 'aaa'
+
+        class MyComponent extends React.Component {
+          props: { user: User }
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+        : null,
+      errors: [
+        {
+          message:
+            'ADVICE: Component property `user` expects to use the generated ' +
+            '`User` flow type. See https://facebook.github.io/relay/docs/relay-compiler.html#importing-generated-definitions.'
         }
       ]
     }

--- a/test/test.js
+++ b/test/test.js
@@ -328,6 +328,26 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       code: `
         import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {|
+          +user: ?MyComponent_user,
+        |}
+
+        class MyComponent extends React.Component {
+          props: Props;
+
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
         type Props = {
           user: MyComponent_user,
         }


### PR DESCRIPTION
Closes #5

Also, We didn't support the case where you could've done something like:

```
type Props = {
  field: ?Container_field,
}
```

(if you set the imported type to be nullable)

This PR fixes that case too :)