### PR TITLE
Remove destructuring assignment to support node.js 4.x

### DIFF
--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -9,7 +9,10 @@
 
 'use strict';
 
-const {parse, visit, Source} = require('graphql');
+const graphql = require('graphql');
+const parse = graphql.parse;
+const visit = graphql.visit;
+const Source = graphql.Source;
 const path = require('path');
 
 function shouldLint(context) {
@@ -89,7 +92,9 @@ function getLocFromIndex(sourceCode, index) {
  * Returns a loc object for error reporting.
  */
 function getLoc(context, templateNode, graphQLNode) {
-  const [start, end] = getRange(context, templateNode, graphQLNode);
+  const startAndEnd = getRange(context, templateNode, graphQLNode);
+  const start = startAndEnd[0];
+  const end = startAndEnd[1];
   return {
     start: getLocFromIndex(context.getSourceCode(), start),
     end: getLocFromIndex(context.getSourceCode(), end)


### PR DESCRIPTION
**what is the change?:**
Changed two cases of destructuring assignment to use older style JS.

**why make this change?:**
In Draft.js we support development with node.js 4.x, which does not
support ES6 destructuring.[1]

We also use this plug-in, since it is a peer dependency of
eslint-config-fbjs.[2]

[1]: https://github.com/nodejs/node/issues/3101
[2]: https://github.com/facebook/fbjs/blob/master/packages/eslint-config-fbjs/package.json#L29

**test plan:**
I locally made these changes, ran `yarn lint` when running node v4.8.4,
and it didn't throw errors.

Otherwise it was throwing this error -
```
Unexpected token {

Referenced from: /home/travis/build/facebook/draft-js/.eslintrc.js

SyntaxError: Unexpected token {

Referenced from: /home/travis/build/facebook/draft-js/.eslintrc.js

    at exports.runInThisContext (vm.js:53:16)

    at Module._compile (module.js:373:25)

    at Object.Module._extensions..js (module.js:416:10)

    at Module.load (module.js:343:32)

    at Function.Module._load (module.js:300:12)

    at Module.require (module.js:353:17)

    at require (internal/module.js:12:17)

    at Plugins.load (/home/travis/build/facebook/draft-js/node_modules/eslint/lib/config/plugins.js:128:26)

    at Array.forEach (native)

    at Plugins.loadAll (/home/travis/build/facebook/draft-js/node_modules/eslint/lib/config/plugins.js:173:21)
```

**issue:**
No issue open, CI is just failing on Draft.js github.
https://github.com/facebook/draft-js/pull/1349

For now removing support of node 4.x but would like to add it back.