### PR TITLE
Ignore syntax error in unused-field rule

### DIFF
--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -52,10 +52,6 @@ function getGraphQLFieldNames(graphQLAst) {
   return fieldNames;
 }
 
-function getGraphQLString(templateLiteral) {
-  return templateLiteral.quasi.quasis[0].value.cooked;
-}
-
 function isGraphQLTemplate(node) {
   return (
     node.tag.type === 'Identifier' &&
@@ -128,6 +124,10 @@ function rule(context) {
     'Program:exit'(node) {
       templateLiterals.forEach(templateLiteral => {
         const graphQLAst = getGraphQLAST(templateLiteral);
+        if (!graphQLAst) {
+          // ignore nodes with syntax errors, they're handled by rule-graphql-syntax
+          return;
+        }
 
         const queriedFields = getGraphQLFieldNames(graphQLAst);
         for (const field in queriedFields) {

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -35,6 +35,8 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
       props.page.name;
       foo.name2;
     `,
+    // Syntax error is ignored by this rule
+    `graphql\`fragment Test { name2 }\`;`,
     `
       graphql\`fragment Test on InternalTask {
         owner: task_owner {


### PR DESCRIPTION
Syntax errors are handled by `rule-graphql-syntax`, everything else
should just ignore invalid syntax.

Fixes #39