### PR TITLE
Allow future added value within default case cast

### DIFF
--- a/src/rule-no-future-added-value.js
+++ b/src/rule-no-future-added-value.js
@@ -9,16 +9,6 @@
 
 'use strict';
 
-const path = require('path');
-
-const utils = require('./utils');
-const getLoc = utils.getLoc;
-const isGraphQLTag = utils.isGraphQLTag;
-
-const graphql = require('graphql');
-const parse = graphql.parse;
-const Source = graphql.Source;
-
 module.exports = context => {
   function validateValue(node) {
     if (node.value === '%future added value') {
@@ -31,7 +21,10 @@ module.exports = context => {
     }
   }
   return {
-    Literal: validateValue,
-    StringLiteralTypeAnnotation: validateValue
+    "Literal[value='%future added value']": validateValue,
+
+    // StringLiteralTypeAnnotations that are not children of a default case
+    [':not(SwitchCase[test=null] StringLiteralTypeAnnotation)' +
+    "StringLiteralTypeAnnotation[value='%future added value']"]: validateValue
   };
 };

--- a/test/future-added-value.js
+++ b/test/future-added-value.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+var eslint = require('eslint');
+
+const rules = require('..').rules;
+const RuleTester = eslint.RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: {ecmaVersion: 6, sourceType: 'module'}
+});
+
+const FUTURE_ADDED_VALUE_MESSAGE =
+  "Do not use `'%future added value'`. It represents any potential " +
+  'value that the server might return in the future that the code ' +
+  'should handle.';
+
+ruleTester.run('no-future-added-value', rules['no-future-added-value'], {
+  valid: [
+    `const response: 'YES' | 'NO' = 'YES';`,
+    `
+      const response: 'YES' | 'NO' = 'YES';
+      switch (response) {
+        case 'YES':
+          break;
+        case 'NO':
+          break;
+        default:
+          (response: '%future added value');
+      }
+    `
+  ],
+  invalid: [
+    {
+      // value location
+      code: `const response: 'YES' | 'NO' = '%future added value';`,
+      errors: [
+        {
+          message: FUTURE_ADDED_VALUE_MESSAGE
+        }
+      ]
+    },
+    {
+      // type location
+      code: `function test(x: 'EXAMPLE'|'%future added value'){ }`,
+      errors: [
+        {
+          message: FUTURE_ADDED_VALUE_MESSAGE
+        }
+      ]
+    },
+    {
+      code: `
+        const response: 'YES' | 'NO' = 'YES';
+        switch (response) {
+          case 'YES':
+            break;
+          case 'NO':
+            break;
+          case '%future added value':
+            break;
+          default:
+            (response: '%future added value');
+        }
+      `,
+      errors: [
+        {
+          message: FUTURE_ADDED_VALUE_MESSAGE
+        }
+      ]
+    },
+    {
+      // using future added value not in typecasting
+      code: `
+        const response: 'YES' | 'NO' = 'YES';
+        switch (response) {
+          case 'YES':
+            break;
+          case 'NO':
+            break;
+          default:
+            const foo = '%future added value';
+        }
+      `,
+      errors: [
+        {
+          message: FUTURE_ADDED_VALUE_MESSAGE
+        }
+      ]
+    }
+  ]
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1322,31 +1322,3 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     }
   ]
 });
-
-const FUTURE_ADDED_VALUE_MESSAGE =
-  "Do not use `'%future added value'`. It represents any potential " +
-  'value that the server might return in the future that the code ' +
-  'should handle.';
-ruleTester.run('no-future-added-value', rules['no-future-added-value'], {
-  valid: valid.concat([`const response: 'YES' | 'NO' = 'YES';`]),
-  invalid: [
-    {
-      // value location
-      code: `const response: 'YES' | 'NO' = '%future added value';`,
-      errors: [
-        {
-          message: FUTURE_ADDED_VALUE_MESSAGE
-        }
-      ]
-    },
-    {
-      // type location
-      code: `function test(x: 'EXAMPLE'|'%future added value'){ }`,
-      errors: [
-        {
-          message: FUTURE_ADDED_VALUE_MESSAGE
-        }
-      ]
-    }
-  ]
-});


### PR DESCRIPTION
Allow using `%future added value` within a cast in the default case of a switch statement. Use this to get an exhaustive switch case in flow while also requiring an explicit default value:

```js
// type SomeRelayEnum = 'FOO' | 'BAR' | '%future added value';
function test(foo: SomeRelayEnum): string {
  switch(foo) {
    case 'FOO':
      return 'foo';
    case 'BAR':
      return 'bar';
    default:
      (foo: '%future added value');
      return 'default';
  }
}
```

[Try Flow](https://flow.org/try/#0C4TwDgpgBAyg9gWwgJQgGwIYgKIDsCuCUAvFAOQBiA8lWVAD7kBCAgsnY2QKQBm+w+AE7QMAE1ERRUAG4Y0+CGQDcAKBV9cAY2ABLOLijAIAZ2AAKHnDgAuWIhToseQgEpbpwTtwBzKAG8VKChjAHcdYE0ACwsrF39AoKhNDGNoShoyawTEqGEBQQMySzhlbKSUtNZ2LJygvKFCgCMMQVKciR4MfDRgGtqYm3JefiERcUkZOQUyF1Va3Ih8wo6unraoAF8VDaA)

Added test cases, ran `yarn test`, ran `yarn run prettier`