### PR TITLE
Ignore __typename in unused field rule

### DIFF
--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -130,7 +130,13 @@ function rule(context) {
 
         const queriedFields = getGraphQLFieldNames(graphQLAst);
         for (const field in queriedFields) {
-          if (!foundMemberAccesses[field] && !isPageInfoField(field)) {
+          if (
+            !foundMemberAccesses[field] &&
+            !isPageInfoField(field) &&
+            // Do not warn for unused __typename which can be a workaround
+            // when only interested in existence of an object.
+            field !== '__typename'
+          ) {
             context.report({
               node: templateLiteral,
               loc: utils.getLoc(context, templateLiteral, queriedFields[field]),

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -144,7 +144,9 @@ function rule(context) {
                 `This queries for the field \`${field}\` but this file does ` +
                 'not seem to use it directly. If a different file needs this ' +
                 'information that file should export a fragment and colocate ' +
-                'the query for the data with the usage.'
+                'the query for the data with the usage.\n' +
+                'If only interested in the existence of a record, __typename ' +
+                'can be used without this warning.'
             });
           }
         }

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -35,6 +35,7 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
       props.page.name;
       foo.name2;
     `,
+    'graphql`fragment foo on Page { __typename }`;',
     // Syntax error is ignored by this rule
     `graphql\`fragment Test { name2 }\`;`,
     `

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -24,7 +24,9 @@ function unusedFieldsWarning(field) {
     `This queries for the field \`${field}\` but this file does ` +
     'not seem to use it directly. If a different file needs this ' +
     'information that file should export a fragment and colocate ' +
-    'the query for the data with the usage.'
+    'the query for the data with the usage.\n' +
+    'If only interested in the existence of a record, __typename ' +
+    'can be used without this warning.'
   );
 }
 


### PR DESCRIPTION
Sometimes, it's useful to just know the existence of an object, but the GraphQL spec enforces that some field is queried. This ignores `__typename` to have a generally cheap field that doesn't trigger the linter.