### PR TITLE
Require MyFragment$key type for useFragment

### DIFF
--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -339,7 +339,7 @@ module.exports = {
               return importDeclaration.specifiers.some(
                 specifier =>
                   specifier.type === 'ImportSpecifier' &&
-                  specifier.imported.name === fragmentName + '$ref'
+                  specifier.imported.name === fragmentName + '$key'
               );
             }
             // import {type xyz} from '...';
@@ -348,7 +348,7 @@ module.exports = {
                 specifier =>
                   specifier.type === 'ImportSpecifier' &&
                   specifier.importKind === 'type' &&
-                  specifier.imported.name === fragmentName + '$ref'
+                  specifier.imported.name === fragmentName + '$key'
               );
             }
             return false;
@@ -358,10 +358,10 @@ module.exports = {
               node: node,
               message:
                 'The prop passed to useFragment() should be typed with the ' +
-                "type '{{name}}$ref' imported from '{{name}}.graphql', " +
+                "type '{{name}}$key' imported from '{{name}}.graphql', " +
                 'e.g.:\n' +
                 '\n' +
-                "  import type {{{name}}} from '{{name}}.graphql';",
+                "  import type {{{name}}$key} from '{{name}}.graphql';",
               data: {
                 name: fragmentName
               }

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -336,30 +336,22 @@ module.exports = {
             }
             // import type {...} from '...';
             if (importDeclaration.importKind === 'type') {
-              return importDeclaration.specifiers.some(specifier => {
-                console.log(
-                  // specifier,
-                  'HERE',
-                  specifier.importKind,
-                  specifier.type === 'ImportSpecifier',
-                  specifier.imported.name === fragmentName + '$ref'
-                );
-                return (
+              return importDeclaration.specifiers.some(
+                specifier =>
                   specifier.type === 'ImportSpecifier' &&
                   specifier.imported.name === fragmentName + '$ref'
-                );
-              });
+              );
             }
             // import {type xyz} from '...';
             if (importDeclaration.importKind === 'value') {
-              return importDeclaration.specifiers.some(specifier => {
-                return (
+              return importDeclaration.specifiers.some(
+                specifier =>
                   specifier.type === 'ImportSpecifier' &&
                   specifier.importKind === 'type' &&
                   specifier.imported.name === fragmentName + '$ref'
-                );
-              });
+              );
             }
+            return false;
           });
           if (!foundImport) {
             context.report({

--- a/test/test.js
+++ b/test/test.js
@@ -210,13 +210,19 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {code: 'graphql`query {{{`'},
     {
       code: `
-        import type {TestFragment_foo} from 'TestFragment_foo.graphql';
+        import type {TestFragment_foo$ref} from 'TestFragment_foo.graphql';
         useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
       `
     },
     {
       code: `
-        import type {TestFragment_foo} from './path/to/TestFragment_foo.graphql';
+        import type {TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
+        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+      `
+    },
+    {
+      code: `
+        import {type TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
         useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
       `
     },
@@ -421,15 +427,48 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
   invalid: [
     {
       code: `
-        import type {TestFragment_other} from './path/to/TestFragment_other.graphql';
+        import type {TestFragment_other$ref} from './path/to/TestFragment_other.graphql';
         useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
       `,
       errors: [
         {
           message: `
-The prop passed to useFragment() should be typed with the type TestFragment_foo imported from TestFragment_foo.graphql, e.g.:
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
 
-  import type {TestFragment_foo} from 'TestFragment_foo.graphql;`.trim(),
+  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      // Should import the type
+      code: `
+        import {TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
+        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+      `,
+      errors: [
+        {
+          message: `
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        import type {other} from 'TestFragment_foo.graphql';
+        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+      `,
+      errors: [
+        {
+          message: `
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
           line: 3,
           column: 9
         }

--- a/test/test.js
+++ b/test/test.js
@@ -210,20 +210,20 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {code: 'graphql`query {{{`'},
     {
       code: `
-        import type {TestFragment_foo$ref} from 'TestFragment_foo.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `
     },
     {
       code: `
-        import type {TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        import type {TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `
     },
     {
       code: `
-        import {type TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        import {type TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `
     },
     {code: 'useQuery<FooResponse>(graphql`query Foo { id }`)'},
@@ -426,33 +426,34 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
   ]),
   invalid: [
     {
+      // imports TestFragment_other$key instead of TestFragment_foo$key
       code: `
-        import type {TestFragment_other$ref} from './path/to/TestFragment_other.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        import type {TestFragment_other$key} from './path/to/TestFragment_other.graphql';
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `,
       errors: [
         {
           message: `
-The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
 
-  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
           line: 3,
           column: 9
         }
       ]
     },
     {
-      // Should import the type
+      // Should import the type using `import type {xyz} from ...` or `import {type xyz} from ...`
       code: `
-        import {TestFragment_foo$ref} from './path/to/TestFragment_foo.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        import {TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `,
       errors: [
         {
           message: `
-The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
 
-  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
           line: 3,
           column: 9
         }
@@ -461,14 +462,14 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
     {
       code: `
         import type {other} from 'TestFragment_foo.graphql';
-        useFragment<FooResponse>(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`query TestFragment_foo { id }\`)
       `,
       errors: [
         {
           message: `
-The prop passed to useFragment() should be typed with the type 'TestFragment_foo$ref' imported from 'TestFragment_foo.graphql', e.g.:
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
 
-  import type {TestFragment_foo} from 'TestFragment_foo.graphql';`.trim(),
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
           line: 3,
           column: 9
         }


### PR DESCRIPTION
This makes the lint for useFragment flow typing more strict by requiring
the import of the `xyz$key` type instead of anything from the generated
module.