### PR TITLE
Fix generated flow type rule w readonly/aliased types

### DIFF
--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -481,8 +481,10 @@ module.exports = {
                       })
                       .filter(maybeObjectType => {
                         // GenericTypeAnnotation may not map to an object type
-                        return maybeObjectType &&
-                          maybeObjectType.type === 'ObjectTypeAnnotation';
+                        return (
+                          maybeObjectType &&
+                          maybeObjectType.type === 'ObjectTypeAnnotation'
+                        );
                       });
                     if (!objectTypes.length) {
                       // The type Alias is likely being imported.

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -212,6 +212,34 @@ function getDefinitionName(arg) {
   return ast.definitions[0].name.value;
 }
 
+function extractReadOnlyType(genericType) {
+  let currentType = genericType;
+  while (
+    currentType != null &&
+    currentType.type === 'GenericTypeAnnotation' &&
+    currentType.id.name === '$ReadOnly' &&
+    currentType.typeParameters &&
+    currentType.typeParameters.type === 'TypeParameterInstantiation' &&
+    Array.isArray(currentType.typeParameters.params) &&
+    currentType.typeParameters.params.length === 1
+  ) {
+    currentType = currentType.typeParameters.params[0];
+  }
+  return currentType;
+}
+
+function resolveTypeAlias(genericType, typeAliasMap) {
+  let currentType = genericType;
+  while (
+    currentType != null &&
+    currentType.type === 'GenericTypeAnnotation' &&
+    typeAliasMap[currentType.id.name] != null
+  ) {
+    currentType = typeAliasMap[currentType.id.name];
+  }
+  return currentType;
+}
+
 module.exports = {
   meta: {
     fixable: 'code',
@@ -419,57 +447,63 @@ module.exports = {
                 break;
               }
               case 'GenericTypeAnnotation': {
-                const alias = propType.id.name;
-                if (!typeAliasMap[alias]) {
+                const aliasedObjectType = extractReadOnlyType(
+                  resolveTypeAlias(propType, typeAliasMap)
+                );
+                if (!aliasedObjectType) {
                   // The type Alias doesn't exist, is invalid, or is being
                   // imported. Can't do anything.
                   break;
                 }
-                switch (typeAliasMap[alias].type) {
+                switch (aliasedObjectType.type) {
                   case 'ObjectTypeAnnotation': {
                     validateObjectTypeAnnotation(
                       context,
                       Component,
                       importedPropType,
                       propName,
-                      typeAliasMap[alias],
+                      aliasedObjectType,
                       importFixRange
                     );
                     break;
                   }
                   case 'IntersectionTypeAnnotation': {
-                    const objectTypes = typeAliasMap[alias].types
+                    const objectTypes = aliasedObjectType.types
                       .map(intersectedType => {
                         if (intersectedType.type === 'GenericTypeAnnotation') {
-                          return typeAliasMap[intersectedType.id.name];
+                          return extractReadOnlyType(
+                            resolveTypeAlias(intersectedType, typeAliasMap)
+                          );
                         }
                         if (intersectedType.type === 'ObjectTypeAnnotation') {
                           return intersectedType;
                         }
                       })
-                      .filter(Boolean);
+                      .filter(maybeObjectType => {
+                        // GenericTypeAnnotation may not map to an object type
+                        return maybeObjectType &&
+                          maybeObjectType.type === 'ObjectTypeAnnotation';
+                      });
                     if (!objectTypes.length) {
                       // The type Alias is likely being imported.
                       // Can't do anything.
                       break;
                     }
-                    const lintResults = objectTypes.map(
-                      objectType =>
-                        objectType.type === 'ObjectTypeAnnotation' &&
-                        validateObjectTypeAnnotation(
-                          context,
-                          Component,
-                          importedPropType,
-                          propName,
-                          objectType,
-                          importFixRange,
-                          true // Return false if invalid instead of reporting
-                        )
-                    );
-                    if (lintResults.some(result => result)) {
-                      // One of the intersected objects has it right
-                      break;
+                    for (const objectType of objectTypes) {
+                      const isValid = validateObjectTypeAnnotation(
+                        context,
+                        Component,
+                        importedPropType,
+                        propName,
+                        objectType,
+                        importFixRange,
+                        true // Return false if invalid instead of reporting
+                      );
+                      if (isValid) {
+                        break;
+                      }
                     }
+                    // otherwise report an error at the first object
                     validateObjectTypeAnnotation(
                       context,
                       Component,

--- a/test/test.js
+++ b/test/test.js
@@ -401,7 +401,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
           user: graphql\`fragment MyComponent_user on User {id}\`,
         });
       `
-    },
+    }
   ]),
   invalid: [
     {

--- a/test/test.js
+++ b/test/test.js
@@ -402,27 +402,6 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         });
       `
     },
-    {
-      code: `
-        type RelayProps = {
-          user: MyComponent_user
-        }
-
-        type Props = {
-          other: ?Object,
-        } & RelayProps;
-
-        class MyComponent extends React.Component<Props> {
-          render() {
-            return <div />;
-          }
-        }
-
-        createFragmentContainer(MyComponent, {
-          user: graphql\`fragment MyComponent_user on User {id}\`,
-        });
-      `
-    }
   ]),
   invalid: [
     {
@@ -1342,6 +1321,37 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
           message:
             'Component property `user` expects to use the generated ' +
             '`MyComponent_user` flow type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+          line: 10,
+          column: 15
+        }
+      ]
+    },
+    {
+      filename: 'MyComponent.jsx',
+      code: `
+        type RelayProps = {
+          user: MyComponent_user
+        }
+
+        type Props = {
+          other: ?Object,
+        } & RelayProps;
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+      errors: [
+        {
+          message:
+            '`user` is not declared in the `props` of the React component or it is not marked with the generated flow type `MyComponent_user`. ' +
+            'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
           line: 10,
           column: 15
         }


### PR DESCRIPTION
Fixes a fatal where `validateObjectTypeAnnotation()` fatals when passed an unexpected value (when  `propType` isn't an `ObjectTypeAnnotation` as expected). This can occur when GenericTypeAnnotations aren't filtered later in the file. The simple fix was to just filter out non-ObjectTypeAnnotation values, but I noticed this bug because of an example involving `$ReadOnly<Props>`. I realized we aren't unwrapping ReadOnly values, and also aren't fully resolving aliases, so I implemented support for those and then filtered out non-object types only afterwards.