### PR TITLE
Allow graphql_DEPRECATED tag

### DIFF
--- a/src/rule-graphql-naming.js
+++ b/src/rule-graphql-naming.js
@@ -15,6 +15,7 @@ const getLoc = utils.getLoc;
 const getModuleName = utils.getModuleName;
 const getRange = utils.getRange;
 const isGraphQLTag = utils.isGraphQLTag;
+const isGraphQLDeprecatedTag = utils.isGraphQLDeprecatedTag;
 const shouldLint = utils.shouldLint;
 
 const CREATE_CONTAINER_FUNCTIONS = new Set([
@@ -149,7 +150,10 @@ module.exports = {
               property.computed === false &&
               property.value.type === 'TaggedTemplateExpression'
             ) {
-              if (!isGraphQLTag(property.value.tag)) {
+              if (
+                !isGraphQLTag(property.value.tag) &&
+                !isGraphQLDeprecatedTag(property.value.tag)
+              ) {
                 context.report({
                   node: property.value.tag,
                   message:

--- a/src/utils.js
+++ b/src/utils.js
@@ -95,6 +95,10 @@ function isGraphQLTag(tag) {
   return tag.type === 'Identifier' && tag.name === 'graphql';
 }
 
+function isGraphQLDeprecatedTag(tag) {
+  return tag.type === 'Identifier' && tag.name === 'graphql_DEPRECATED';
+}
+
 function shouldLint(context) {
   return /graphql|relay/i.test(context.getSourceCode().text);
 }
@@ -106,5 +110,6 @@ module.exports = {
   getModuleName: getModuleName,
   getRange: getRange,
   isGraphQLTag: isGraphQLTag,
+  isGraphQLDeprecatedTag: isGraphQLDeprecatedTag,
   shouldLint: shouldLint
 };

--- a/test/test.js
+++ b/test/test.js
@@ -43,6 +43,12 @@ const valid = [
     code: `createFragmentContainer(Component, {
       user: graphql\`fragment MyComponent_user on User {id}\`,
     });`
+  },
+  {
+    filename: 'path/to/MyDeprecatedComponent.jsx',
+    code: `createFragmentContainer(Component, {
+      user: graphql_DEPRECATED\`fragment MyComponent_user on User {id}\`,
+    });`
   }
 ];
 


### PR DESCRIPTION
This is used for internal migration to split legacy RelayCompat code
from RelayModern.