### PR TITLE
Also verify correct ref type is used for useRefetchable and usePagination fragments

### DIFF
--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -312,10 +312,6 @@ module.exports = {
        * Find usePaginationFragment() calls without type arguments.
        */
       'CallExpression[callee.name=usePaginationFragment]:not([typeArguments])'(node) {
-        const firstArg = node.arguments[0];
-        if (firstArg == null) {
-          return;
-        }
         const queryName = 'PaginationQuery';
         context.report({
           node: node,
@@ -331,10 +327,6 @@ module.exports = {
        * Find useRefetchableFragment() calls without type arguments.
        */
       'CallExpression[callee.name=useRefetchableFragment]:not([typeArguments])'(node) {
-        const firstArg = node.arguments[0];
-        if (firstArg == null) {
-          return;
-        }
         const queryName = 'RefetchableQuery';
         context.report({
           node: node,

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -311,7 +311,9 @@ module.exports = {
       /**
        * Find usePaginationFragment() calls without type arguments.
        */
-      'CallExpression[callee.name=usePaginationFragment]:not([typeArguments])'(node) {
+      'CallExpression[callee.name=usePaginationFragment]:not([typeArguments])'(
+        node
+      ) {
         const queryName = 'PaginationQuery';
         context.report({
           node: node,
@@ -326,7 +328,9 @@ module.exports = {
       /**
        * Find useRefetchableFragment() calls without type arguments.
        */
-      'CallExpression[callee.name=useRefetchableFragment]:not([typeArguments])'(node) {
+      'CallExpression[callee.name=useRefetchableFragment]:not([typeArguments])'(
+        node
+      ) {
         const queryName = 'RefetchableQuery';
         context.report({
           node: node,

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -309,6 +309,44 @@ module.exports = {
       },
 
       /**
+       * Find usePaginationFragment() calls without type arguments.
+       */
+      'CallExpression[callee.name=usePaginationFragment]:not([typeArguments])'(node) {
+        const firstArg = node.arguments[0];
+        if (firstArg == null) {
+          return;
+        }
+        const queryName = 'PaginationQuery';
+        context.report({
+          node: node,
+          message:
+            'The `usePaginationFragment` hook should be used with an explicit generated Flow type, e.g.: usePaginationFragment<{{queryName}}, _>(...)',
+          data: {
+            queryName: queryName
+          }
+        });
+      },
+
+      /**
+       * Find useRefetchableFragment() calls without type arguments.
+       */
+      'CallExpression[callee.name=useRefetchableFragment]:not([typeArguments])'(node) {
+        const firstArg = node.arguments[0];
+        if (firstArg == null) {
+          return;
+        }
+        const queryName = 'RefetchableQuery';
+        context.report({
+          node: node,
+          message:
+            'The `useRefetchableFragment` hook should be used with an explicit generated Flow type, e.g.: useRefetchableFragment<{{queryName}}, _>(...)',
+          data: {
+            queryName: queryName
+          }
+        });
+      },
+
+      /**
        * useFragment() calls
        */
       'CallExpression[callee.name=useFragment]'(node) {

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -272,6 +272,23 @@ module.exports = {
     const requires = [];
     const typeAliasMap = {};
     const useFragmentInstances = [];
+
+    function trackHookCall(node, hookName) {
+      const firstArg = node.arguments[0];
+      if (firstArg == null) {
+        return;
+      }
+      const fragmentName = getDefinitionName(firstArg);
+      if (fragmentName == null) {
+        return;
+      }
+      useFragmentInstances.push({
+        fragmentName: fragmentName,
+        node: node,
+        hookName: hookName
+      });
+    }
+
     return {
       ImportDeclaration(node) {
         imports.push(node);
@@ -346,57 +363,21 @@ module.exports = {
        * useFragment() calls
        */
       'CallExpression[callee.name=useFragment]'(node) {
-        const firstArg = node.arguments[0];
-        if (firstArg == null) {
-          return;
-        }
-        const fragmentName = getDefinitionName(firstArg);
-        if (fragmentName == null) {
-          return;
-        }
-        useFragmentInstances.push({
-          fragmentName: fragmentName,
-          node: node,
-          hookName: 'useFragment'
-        });
+        trackHookCall(node, 'useFragment');
       },
 
       /**
        * usePaginationFragment() calls
        */
       'CallExpression[callee.name=usePaginationFragment]'(node) {
-        const firstArg = node.arguments[0];
-        if (firstArg == null) {
-          return;
-        }
-        const fragmentName = getDefinitionName(firstArg);
-        if (fragmentName == null) {
-          return;
-        }
-        useFragmentInstances.push({
-          fragmentName: fragmentName,
-          node: node,
-          hookName: 'usePaginationFragment'
-        });
+        trackHookCall(node, 'usePaginationFragment');
       },
 
       /**
        * useRefetchableFragment() calls
        */
       'CallExpression[callee.name=useRefetchableFragment]'(node) {
-        const firstArg = node.arguments[0];
-        if (firstArg == null) {
-          return;
-        }
-        const fragmentName = getDefinitionName(firstArg);
-        if (fragmentName == null) {
-          return;
-        }
-        useFragmentInstances.push({
-          fragmentName: fragmentName,
-          node: node,
-          hookName: 'useRefetchableFragment'
-        });
+        trackHookCall(node, 'useRefetchableFragment');
       },
 
       ClassDeclaration(node) {

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -356,7 +356,46 @@ module.exports = {
         }
         useFragmentInstances.push({
           fragmentName: fragmentName,
-          node: node
+          node: node,
+          hookName: 'useFragment'
+        });
+      },
+
+      /**
+       * usePaginationFragment() calls
+       */
+      'CallExpression[callee.name=usePaginationFragment]'(node) {
+        const firstArg = node.arguments[0];
+        if (firstArg == null) {
+          return;
+        }
+        const fragmentName = getDefinitionName(firstArg);
+        if (fragmentName == null) {
+          return;
+        }
+        useFragmentInstances.push({
+          fragmentName: fragmentName,
+          node: node,
+          hookName: 'usePaginationFragment'
+        });
+      },
+
+      /**
+       * useRefetchableFragment() calls
+       */
+      'CallExpression[callee.name=useRefetchableFragment]'(node) {
+        const firstArg = node.arguments[0];
+        if (firstArg == null) {
+          return;
+        }
+        const fragmentName = getDefinitionName(firstArg);
+        if (fragmentName == null) {
+          return;
+        }
+        useFragmentInstances.push({
+          fragmentName: fragmentName,
+          node: node,
+          hookName: 'useRefetchableFragment'
         });
       },
 
@@ -389,6 +428,7 @@ module.exports = {
       'Program:exit': function(_node) {
         useFragmentInstances.forEach(useFragmentInstance => {
           const fragmentName = useFragmentInstance.fragmentName;
+          const hookName = useFragmentInstance.hookName;
           const node = useFragmentInstance.node;
           const foundImport = imports.some(importDeclaration => {
             const importedFromModuleName = importDeclaration.source.value;
@@ -419,13 +459,14 @@ module.exports = {
             context.report({
               node: node,
               message:
-                'The prop passed to useFragment() should be typed with the ' +
+                'The prop passed to {{hookName}}() should be typed with the ' +
                 "type '{{name}}$key' imported from '{{name}}.graphql', " +
                 'e.g.:\n' +
                 '\n' +
                 "  import type {{{name}}$key} from '{{name}}.graphql';",
               data: {
-                name: fragmentName
+                name: fragmentName,
+                hookName: hookName
               }
             });
           }

--- a/test/test.js
+++ b/test/test.js
@@ -217,22 +217,25 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `
     },
     {
       code: `
         import type {TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `
     },
     {
       code: `
         import {type TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `
     },
-    {code: 'useQuery<FooResponse>(graphql`query Foo { id }`)'},
+    {code: 'useRefetchableFragment<RefetchableQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'},
+    {code: 'usePaginationFragment<PaginationQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'},
+    {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
+    {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
     {
       code: `
         import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
@@ -414,7 +417,7 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       // imports TestFragment_other$key instead of TestFragment_foo$key
       code: `
         import type {TestFragment_other$key} from './path/to/TestFragment_other.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
       errors: [
         {
@@ -431,7 +434,7 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
       // Should import the type using `import type {xyz} from ...` or `import {type xyz} from ...`
       code: `
         import {TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
       errors: [
         {
@@ -447,7 +450,7 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
     {
       code: `
         import type {other} from 'TestFragment_foo.graphql';
-        useFragment(graphql\`query TestFragment_foo { id }\`)
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
       errors: [
         {
@@ -457,6 +460,28 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
           line: 3,
           column: 9
+        }
+      ]
+    },
+    {
+      code: 'useRefetchableFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      errors: [
+        {
+          message:
+            'The `useRefetchableFragment` hook should be used with an explicit generated Flow type, e.g.: useRefetchableFragment<RefetchableQuery, _>(...)',
+          line: 1,
+          column: 1
+        }
+      ]
+    },
+    {
+      code: 'usePaginationFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      errors: [
+        {
+          message:
+            'The `usePaginationFragment` hook should be used with an explicit generated Flow type, e.g.: usePaginationFragment<PaginationQuery, _>(...)',
+          line: 1,
+          column: 1
         }
       ]
     },

--- a/test/test.js
+++ b/test/test.js
@@ -232,8 +232,14 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
         useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
       `
     },
-    {code: 'useRefetchableFragment<RefetchableQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'},
-    {code: 'usePaginationFragment<PaginationQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'},
+    {
+      code:
+        'useRefetchableFragment<RefetchableQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'
+    },
+    {
+      code:
+        'usePaginationFragment<PaginationQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'
+    },
     {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
     {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
     {
@@ -464,7 +470,8 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
       ]
     },
     {
-      code: 'useRefetchableFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      code:
+        'useRefetchableFragment(graphql`fragment TestFragment_foo on User { id }`)',
       errors: [
         {
           message:
@@ -475,7 +482,8 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
       ]
     },
     {
-      code: 'usePaginationFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      code:
+        'usePaginationFragment(graphql`fragment TestFragment_foo on User { id }`)',
       errors: [
         {
           message:

--- a/test/test.js
+++ b/test/test.js
@@ -233,12 +233,16 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
       `
     },
     {
-      code:
-        'useRefetchableFragment<RefetchableQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useRefetchableFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
     },
     {
-      code:
-        'usePaginationFragment<PaginationQuery, _>(graphql`fragment TestFragment_foo on User { id }`)'
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
     },
     {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
     {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
@@ -470,26 +474,60 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
       ]
     },
     {
-      code:
-        'useRefetchableFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useRefetchableFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
       errors: [
         {
           message:
             'The `useRefetchableFragment` hook should be used with an explicit generated Flow type, e.g.: useRefetchableFragment<RefetchableQuery, _>(...)',
-          line: 1,
-          column: 1
+          line: 3,
+          column: 9
         }
       ]
     },
     {
-      code:
-        'usePaginationFragment(graphql`fragment TestFragment_foo on User { id }`)',
+      code: `
+        useRefetchableFragment<RefetchQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message: `
+The prop passed to useRefetchableFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+          line: 2,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
       errors: [
         {
           message:
             'The `usePaginationFragment` hook should be used with an explicit generated Flow type, e.g.: usePaginationFragment<PaginationQuery, _>(...)',
-          line: 1,
-          column: 1
+          line: 3,
+          column: 9
+        }
+      ]
+    },
+    {
+      code: `
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message: `
+The prop passed to usePaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+          line: 2,
+          column: 9
         }
       ]
     },


### PR DESCRIPTION
This commit ensures that we also verify that the correct ref types are imported when using `useRefetchableFragment` and `usePaginationFragment`. Currently we only do so for `useFragment`.

Test Plan:
- New and updated unit tests