### PR TITLE
Fix detection of Relay props usage defined in $ReadOnly or type alias

### DIFF
--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -85,11 +85,23 @@ function getPropTypeProperty(
   propName,
   visitedProps = new Set()
 ) {
-  if (propType == null || !propType.properties || visitedProps.has(propType)) {
+  if (propType == null || visitedProps.has(propType)) {
     return null;
   }
   visitedProps.add(propType);
   const spreadsToVisit = [];
+  if (propType.type === 'GenericTypeAnnotation') {
+    return getPropTypeProperty(
+      context,
+      typeAliasMap,
+      extractReadOnlyType(resolveTypeAlias(propType, typeAliasMap)),
+      propName,
+      visitedProps
+    );
+  }
+  if (propType.type !== 'ObjectTypeAnnotation') {
+    return null;
+  }
   for (const property of propType.properties) {
     if (property.type === 'ObjectTypeSpreadProperty') {
       spreadsToVisit.push(property);

--- a/test/test.js
+++ b/test/test.js
@@ -445,6 +445,85 @@ ruleTester.run('generated-flow-types', rules['generated-flow-types'], {
     {
       code: `
         import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type RealProps = $ReadOnly<{
+          +user: MyComponent_user,
+        }>
+        type RelayProps = $ReadOnly<{|
+          ...RelayProps,
+          ...RealProps
+        |}>
+        type Props = $ReadOnly<{|
+          ...RelayProps,
+          id: 3
+        |}>
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type RealProps = $ReadOnly<{
+          +user: MyComponent_user,
+        }>
+        type RealPropsAlias = RealProps
+        type RealPropsAlias2 = RealPropsAlias
+        type RelayProps = $ReadOnly<{|
+          ...RelayProps,
+          ...RealPropsAlias2
+        |}>
+        type Props = {|
+          ...RelayProps,
+          id: 3
+        |}
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type RealProps = $ReadOnly<{
+          +user: MyComponent_user,
+        }>
+        type RealPropsAlias = RealProps
+        type RelayProps = $ReadOnly<{|
+          ...RelayProps,
+          ...RealPropsAlias
+        |}>
+        type RelayPropsAlias = $ReadOnly<RelayProps>
+        type Props = {|
+          ...RelayPropsAlias,
+          id: 3
+        |}
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+    },
+    {
+      code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
         type Props = {|
           +user: ?MyComponent_user,
         |}


### PR DESCRIPTION
This diff fix the false positive on props defined in `$ReadOnly` or type alias following the object spread in the React Props, 

**Fix**
This reported an error, this is fixed now.
```
import type {MyComponent_user} from 'MyComponent_user.graphql'
type RealProps = $ReadOnly<{
  +user: MyComponent_user,
}>
type RealPropsAlias = RealProps
type RealPropsAlias2 = RealPropsAlias
type RelayProps = $ReadOnly<{|
  ...RelayProps,
  ...RealPropsAlias2
|}>
type Props = {|
  ...RelayProps,
  id: 3
|}
class MyComponent extends React.Component<Props> {
  render() {
    return <div />;
  }
}
```

**Test Plan:**
New tests.
Ran on internal files without JS error.

