### PR TITLE
Ensure the second argument is passed to relay hooks

### DIFF
--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -14,7 +14,8 @@ module.exports = {
     'graphql-naming': require('./src/rule-graphql-naming'),
     'generated-flow-types': require('./src/rule-generated-flow-types'),
     'no-future-added-value': require('./src/rule-no-future-added-value'),
-    'unused-fields': require('./src/rule-unused-fields')
+    'unused-fields': require('./src/rule-unused-fields'),
+    'hook-required-argument': require('./src/rule-hook-required-argument')
   },
   configs: {
     recommended: {
@@ -24,7 +25,8 @@ module.exports = {
         'relay/graphql-naming': 'error',
         'relay/generated-flow-types': 'warn',
         'relay/no-future-added-value': 'warn',
-        'relay/unused-fields': 'warn'
+        'relay/unused-fields': 'warn',
+        'relay/hook-required-argument': 'warn'
       }
     },
     strict: {
@@ -34,7 +36,8 @@ module.exports = {
         'relay/graphql-naming': 'error',
         'relay/generated-flow-types': 'error',
         'relay/no-future-added-value': 'error',
-        'relay/unused-fields': 'error'
+        'relay/unused-fields': 'error',
+        'relay/hook-required-argument': 'error'
       }
     }
   }

--- a/src/rule-hook-required-argument.js
+++ b/src/rule-hook-required-argument.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const utils = require('./utils');
+const shouldLint = utils.shouldLint;
+
+function reportMissingKeyArgument(node, context, hookName) {
+  context.report({
+    node: node,
+    message: `A fragment reference should be passed to the \`${hookName}\` hook`
+  });
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Validates that the second argument is passed to relay hooks.'
+    }
+  },
+  create(context) {
+    if (!shouldLint(context)) {
+      return {};
+    }
+
+    return {
+      'CallExpression[callee.name=useFragment][arguments.length < 2]'(node) {
+        reportMissingKeyArgument(node, context, 'useFragment');
+      },
+      'CallExpression[callee.name=usePaginationFragment][arguments.length < 2]'(
+        node
+      ) {
+        reportMissingKeyArgument(node, context, 'usePaginationFragment');
+      },
+
+      'CallExpression[callee.name=useBlockingPaginationFragment][arguments.length < 2]'(
+        node
+      ) {
+        reportMissingKeyArgument(
+          node,
+          context,
+          'useBlockingPaginationFragment'
+        );
+      },
+
+      'CallExpression[callee.name=useLegacyPaginationFragment][arguments.length < 2]'(
+        node
+      ) {
+        reportMissingKeyArgument(node, context, 'useLegacyPaginationFragment');
+      },
+
+      'CallExpression[callee.name=useRefetchableFragment][arguments.length < 2]'(
+        node
+      ) {
+        reportMissingKeyArgument(node, context, 'useRefetchableFragment');
+      }
+    };
+  }
+};

--- a/test/hook-required-argument.js
+++ b/test/hook-required-argument.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const rules = require('..').rules;
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: 'babel-eslint',
+  parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+});
+
+ruleTester.run('hook-required-argument', rules['hook-required-argument'], {
+  valid: [
+    {
+      code: `
+       import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+       useFragment(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+     `
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useRefetchableFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+      `
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+      `
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+      `
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+      `
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message:
+            'A fragment reference should be passed to the `useFragment` hook',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message:
+            'A fragment reference should be passed to the `usePaginationFragment` hook',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message:
+            'A fragment reference should be passed to the `useBlockingPaginationFragment` hook',
+          line: 3
+        }
+      ]
+    },
+    {
+      code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+      errors: [
+        {
+          message:
+            'A fragment reference should be passed to the `useLegacyPaginationFragment` hook',
+          line: 3
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Currently flow doesn't check if the second argument is passed to hooks when the type is optional, so `useFragment(query)` will pass flow check but it should not be allowed.

This diff adds the check on the second argument.