### PR TITLE
Added lint rule to the `commitMutation` function to enforce type annotation

### DIFF
--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -494,11 +494,9 @@ module.exports = {
           return;
         }
         // Find `mutation` property on the `mutationConfig`
-        const mutationNameProperty = mutationConfig.properties.find(prop => {
-          if (prop.key.name === 'mutation') {
-            return true;
-          }
-        });
+        const mutationNameProperty = mutationConfig.properties.find(
+          prop => prop.key.name === 'mutation'
+        );
         if (
           mutationNameProperty == null ||
           mutationNameProperty.value == null
@@ -509,7 +507,7 @@ module.exports = {
         context.report({
           node: node,
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<{{mutationName}}>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<{{mutationName}}>(...)',
           data: {
             mutationName: mutationName || 'ExampleMutation'
           },
@@ -519,6 +517,54 @@ module.exports = {
                   node,
                   mutationName,
                   mutationName
+                )
+              : null
+        });
+      },
+
+      /**
+       * Find requestSubscription() calls without type arguments.
+       */
+      'CallExpression[callee.name=requestSubscription]:not([typeArguments])'(
+        node
+      ) {
+        const subscriptionConfig = node.arguments && node.arguments[1];
+        if (
+          subscriptionConfig == null ||
+          subscriptionConfig.type !== 'ObjectExpression'
+        ) {
+          return;
+        }
+        const subscriptionNameProperty = subscriptionConfig.properties.find(
+          prop => {
+            if (prop.key.name === 'subscription') {
+              return true;
+            }
+          }
+        );
+
+        if (
+          subscriptionNameProperty == null ||
+          subscriptionNameProperty.value == null
+        ) {
+          return;
+        }
+        const subscriptionName = getDefinitionName(
+          subscriptionNameProperty.value
+        );
+        context.report({
+          node: node,
+          message:
+            'The `requestSubscription` must be used with an explicit generated Flow type, e.g.: requestSubscription<{{subscriptionName}}>(...)',
+          data: {
+            subscriptionName: subscriptionName || 'ExampleSubscription'
+          },
+          fix:
+            subscriptionName != null && options.fix
+              ? createHookOrMutationTypeImportFixer(
+                  node,
+                  subscriptionName,
+                  subscriptionName
                 )
               : null
         });

--- a/test/test.js
+++ b/test/test.js
@@ -901,7 +901,61 @@ import type {FooQuery} from './__generated__/FooQuery.graphql'
       ],
       output: null
     },
-
+    {
+      code: `\ncommitMutation(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 2,
+          column: 1
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+commitMutation<FooMutation>(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`
+    },
+        {
+      code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation(environment, {mutation});
+      `,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 3
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation<FooMutation>(environment, {mutation});
+      `,
+    },
+    {
+      code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation(environment, {mutation: myMutation});
+      `,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 4
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation<FooMutation>(environment, {mutation: myMutation});
+      `,
+    },
     {
       filename: 'MyComponent.jsx',
       code: `

--- a/test/test.js
+++ b/test/test.js
@@ -906,7 +906,7 @@ import type {FooQuery} from './__generated__/FooQuery.graphql'
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 2,
           column: 1
         }
@@ -924,7 +924,7 @@ commitMutation<FooMutation>(environemnt, {mutation: graphql\`mutation FooMutatio
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 3
         }
       ],
@@ -944,7 +944,7 @@ import type {FooMutation} from './__generated__/FooMutation.graphql'
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 4
         }
       ],


### PR DESCRIPTION
This change will help provide better type safety for mutations.