### PR TITLE
Add lint rule for missing type annotation of `requestSubscription`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-relay",
-  "version": "1.3.12",
+  "version": "1.4.0",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "relayjs/eslint-plugin-relay",

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -387,11 +387,21 @@ module.exports = {
       });
     }
 
-    function createHookOrMutationTypeImportFixer(node, queryName, typeText) {
+    function createTypeImportFixer(node, operationName, typeText) {
       return fixer => {
-        const importFixRange = genImportFixRange(queryName, imports, requires);
+        const importFixRange = genImportFixRange(
+          operationName,
+          imports,
+          requires
+        );
         return [
-          genImportFixer(fixer, importFixRange, queryName, options.haste, ''),
+          genImportFixer(
+            fixer,
+            importFixRange,
+            operationName,
+            options.haste,
+            ''
+          ),
           fixer.insertTextAfter(node.callee, `<${typeText}>`)
         ];
       };
@@ -407,11 +417,7 @@ module.exports = {
         },
         fix:
           queryName != null && options.fix
-            ? createHookOrMutationTypeImportFixer(
-                node,
-                queryName,
-                `${queryName}, _`
-              )
+            ? createTypeImportFixer(node, queryName, `${queryName}, _`)
             : null
       });
     }
@@ -451,7 +457,7 @@ module.exports = {
           },
           fix:
             queryName != null && options.fix
-              ? createHookOrMutationTypeImportFixer(node, queryName, queryName)
+              ? createTypeImportFixer(node, queryName, queryName)
               : null
         });
       },
@@ -476,7 +482,7 @@ module.exports = {
           },
           fix:
             queryName != null && options.fix
-              ? createHookOrMutationTypeImportFixer(node, queryName, queryName)
+              ? createTypeImportFixer(node, queryName, queryName)
               : null
         });
       },
@@ -513,11 +519,7 @@ module.exports = {
           },
           fix:
             mutationName != null && options.fix
-              ? createHookOrMutationTypeImportFixer(
-                  node,
-                  mutationName,
-                  mutationName
-                )
+              ? createTypeImportFixer(node, mutationName, mutationName)
               : null
         });
       },
@@ -536,11 +538,7 @@ module.exports = {
           return;
         }
         const subscriptionNameProperty = subscriptionConfig.properties.find(
-          prop => {
-            if (prop.key.name === 'subscription') {
-              return true;
-            }
-          }
+          prop => prop.key.name === 'subscription'
         );
 
         if (
@@ -561,11 +559,7 @@ module.exports = {
           },
           fix:
             subscriptionName != null && options.fix
-              ? createHookOrMutationTypeImportFixer(
-                  node,
-                  subscriptionName,
-                  subscriptionName
-                )
+              ? createTypeImportFixer(node, subscriptionName, subscriptionName)
               : null
         });
       },

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -494,11 +494,9 @@ module.exports = {
           return;
         }
         // Find `mutation` property on the `mutationConfig`
-        const mutationNameProperty = mutationConfig.properties.find(prop => {
-          if (prop.key.name === 'mutation') {
-            return true;
-          }
-        });
+        const mutationNameProperty = mutationConfig.properties.find(
+          prop => prop.key.name === 'mutation'
+        );
         if (
           mutationNameProperty == null ||
           mutationNameProperty.value == null
@@ -509,7 +507,7 @@ module.exports = {
         context.report({
           node: node,
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<{{mutationName}}>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<{{mutationName}}>(...)',
           data: {
             mutationName: mutationName || 'ExampleMutation'
           },
@@ -519,6 +517,54 @@ module.exports = {
                   node,
                   mutationName,
                   mutationName
+                )
+              : null
+        });
+      },
+
+      /**
+       * Find requestSubscription() calls without type arguments.
+       */
+      'CallExpression[callee.name=requestSubscription]:not([typeArguments])'(
+        node
+      ) {
+        const subscriptionConfig = node.arguments && node.arguments[1];
+        if (
+          subscriptionConfig == null ||
+          subscriptionConfig.type !== 'ObjectExpression'
+        ) {
+          return;
+        }
+        const subscriptionNameProperty = subscriptionConfig.properties.find(
+          prop => {
+            if (prop.key.name === 'subscription') {
+              return true;
+            }
+          }
+        );
+
+        if (
+          subscriptionNameProperty == null ||
+          subscriptionNameProperty.value == null
+        ) {
+          return;
+        }
+        const subscriptionName = getDefinitionName(
+          subscriptionNameProperty.value
+        );
+        context.report({
+          node: node,
+          message:
+            'The `requestSubscription` must be used with an explicit generated Flow type, e.g.: requestSubscription<{{subscriptionName}}>(...)',
+          data: {
+            subscriptionName: subscriptionName || 'ExampleSubscription'
+          },
+          fix:
+            subscriptionName != null && options.fix
+              ? createHookOrMutationTypeImportFixer(
+                  node,
+                  subscriptionName,
+                  subscriptionName
                 )
               : null
         });

--- a/test/test.js
+++ b/test/test.js
@@ -901,7 +901,61 @@ import type {FooQuery} from './__generated__/FooQuery.graphql'
       ],
       output: null
     },
-
+    {
+      code: `\ncommitMutation(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 2,
+          column: 1
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+commitMutation<FooMutation>(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`
+    },
+        {
+      code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation(environment, {mutation});
+      `,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 3
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation<FooMutation>(environment, {mutation});
+      `,
+    },
+    {
+      code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation(environment, {mutation: myMutation});
+      `,
+      errors: [
+        {
+          message:
+            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+          line: 4
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation<FooMutation>(environment, {mutation: myMutation});
+      `,
+    },
     {
       filename: 'MyComponent.jsx',
       code: `

--- a/test/test.js
+++ b/test/test.js
@@ -957,6 +957,61 @@ import type {FooMutation} from './__generated__/FooMutation.graphql'
       `,
     },
     {
+      code: `\nrequestSubscription(environemnt, {subscription: graphql\`subscription FooSubscription { id }\`})`,
+      errors: [
+        {
+          message:
+            'The `requestSubscription` must be used with an explicit generated Flow type, e.g.: requestSubscription<FooSubscription>(...)',
+          line: 2,
+          column: 1
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+requestSubscription<FooSubscription>(environemnt, {subscription: graphql\`subscription FooSubscription { id }\`})`
+    },
+        {
+      code: `
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        requestSubscription(environment, {subscription});
+      `,
+      errors: [
+        {
+          message:
+            'The `requestSubscription` must be used with an explicit generated Flow type, e.g.: requestSubscription<FooSubscription>(...)',
+          line: 3
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        requestSubscription<FooSubscription>(environment, {subscription});
+      `,
+    },
+    {
+      code: `
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        const mySubscription = subscription;
+        requestSubscription(environment, {subscription: mySubscription});
+      `,
+      errors: [
+        {
+          message:
+            'The `requestSubscription` must be used with an explicit generated Flow type, e.g.: requestSubscription<FooSubscription>(...)',
+          line: 4
+        }
+      ],
+      options: DEFAULT_OPTIONS,
+      output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        const mySubscription = subscription;
+        requestSubscription<FooSubscription>(environment, {subscription: mySubscription});
+      `,
+    },
+    {
       filename: 'MyComponent.jsx',
       code: `
         class MyComponent extends React.Component<{}> {

--- a/test/test.js
+++ b/test/test.js
@@ -906,7 +906,7 @@ import type {FooQuery} from './__generated__/FooQuery.graphql'
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 2,
           column: 1
         }
@@ -924,7 +924,7 @@ commitMutation<FooMutation>(environemnt, {mutation: graphql\`mutation FooMutatio
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 3
         }
       ],
@@ -944,7 +944,7 @@ import type {FooMutation} from './__generated__/FooMutation.graphql'
       errors: [
         {
           message:
-            'The `commitMutation` should be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
+            'The `commitMutation` must be used with an explicit generated Flow type, e.g.: commitMutation<FooMutation>(...)',
           line: 4
         }
       ],


### PR DESCRIPTION
This rule should help you to use explicit type annotations with subscriptions.
Similar rule we have for `useQuery`, `commitMutation` (in review) and now `requestSubscription`

