### PR TITLE
Fix runtime error in the plugin. Bump version to 1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-relay",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "relayjs/eslint-plugin-relay",

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -501,7 +501,7 @@ module.exports = {
         }
         // Find `mutation` property on the `mutationConfig`
         const mutationNameProperty = mutationConfig.properties.find(
-          prop => prop.key.name === 'mutation'
+          prop => prop.key != null && prop.key.name === 'mutation'
         );
         if (
           mutationNameProperty == null ||
@@ -538,7 +538,7 @@ module.exports = {
           return;
         }
         const subscriptionNameProperty = subscriptionConfig.properties.find(
-          prop => prop.key.name === 'subscription'
+          prop => prop.key != null && prop.key.name === 'subscription'
         );
 
         if (


### PR DESCRIPTION
The was an error: 
```
TypeError: Cannot read property 'name' of undefined
```