### PR TITLE
[unused-fields] Add ignore fields option

### DIFF
--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -18,7 +18,7 @@ const DEFAULT_OPTIONS = {
 function getOptions(optionValue) {
   if (optionValue) {
     return {
-      ignoreFields: optionValue.ignoreFields || []
+      ignoreFields: optionValue.ignoreFields || DEFAULT_OPTIONS.ignoreFields
     };
   }
   return DEFAULT_OPTIONS;

--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -11,6 +11,19 @@ const utils = require('./utils');
 
 const getGraphQLAST = utils.getGraphQLAST;
 
+const DEFAULT_OPTIONS = {
+  ignoreFields: []
+};
+
+function getOptions(optionValue) {
+  if (optionValue) {
+    return {
+      ignoreFields: optionValue.ignoreFields || []
+    };
+  }
+  return DEFAULT_OPTIONS;
+}
+
 function getGraphQLFieldNames(graphQLAst) {
   const fieldNames = {};
 
@@ -82,6 +95,8 @@ function isPageInfoField(field) {
 }
 
 function rule(context) {
+  const options = getOptions(context.options[0]);
+
   let currentMethod = [];
   let foundMemberAccesses = {};
   let templateLiterals = [];
@@ -138,7 +153,8 @@ function rule(context) {
             !isPageInfoField(field) &&
             // Do not warn for unused __typename which can be a workaround
             // when only interested in existence of an object.
-            field !== '__typename'
+            field !== '__typename' &&
+            !options.ignoreFields.includes(field)
           ) {
             context.report({
               node: templateLiteral,

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -83,7 +83,13 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
           }
         }
       \`;
-    `
+    `,
+    {
+      code: `
+        graphql\`fragment Test on Page { id }\`;
+      `,
+      options: [{ignoreFields: ['id']}]
+    }
   ],
   invalid: [
     {
@@ -108,6 +114,13 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         graphql\`fragment Test on Page { unused1, unused2 }\`;
       `,
       errors: [unusedFieldsWarning('unused1'), unusedFieldsWarning('unused2')]
+    },
+    {
+      code: `
+        graphql\`fragment Test on Page { unused1, unused2 }\`;
+      `,
+      options: [{ignoreFields: ['unused1']}],
+      errors: [unusedFieldsWarning('unused2')]
     },
     {
       code: `


### PR DESCRIPTION
### Motivation

I'm trying to enable this rule in my codebase but a few patterns provide a lot of false positives. An example is when using <FlatList /> from React Native, it expects nodes to have an id prop but this is only accessed internally in the FlatList code and not in the current module. Although it is probably possible to use fragments here I think adding more flexibility to the rule by specifying ignored fields can help adopting it.

I was wondering if we should include `__typename` as part of the default ignoredFields and remove the hardcoded check or keep it like this. The only difference it would make is if you specify ignoreFields and relied on `__typename` being ignored then you'd have to add it in your `ignoreFields` list.

### Test plan

Tested on a large relay codebase and added tests.