### PR TITLE
[unused-fields] Add option to check leave fields only

### DIFF
--- a/src/rule-unused-fields.js
+++ b/src/rule-unused-fields.js
@@ -11,6 +11,19 @@ const utils = require('./utils');
 
 const getGraphQLAST = utils.getGraphQLAST;
 
+const DEFAULT_OPTIONS = {
+  ignoreFields: []
+};
+
+function getOptions(optionValue) {
+  if (optionValue) {
+    return {
+      ignoreFields: optionValue.ignoreFields || []
+    };
+  }
+  return DEFAULT_OPTIONS;
+}
+
 function getGraphQLFieldNames(graphQLAst) {
   const fieldNames = {};
 
@@ -82,6 +95,8 @@ function isPageInfoField(field) {
 }
 
 function rule(context) {
+  const options = getOptions(context.options[0]);
+
   let currentMethod = [];
   let foundMemberAccesses = {};
   let templateLiterals = [];
@@ -138,7 +153,8 @@ function rule(context) {
             !isPageInfoField(field) &&
             // Do not warn for unused __typename which can be a workaround
             // when only interested in existence of an object.
-            field !== '__typename'
+            field !== '__typename' &&
+            !options.ignoreFields.includes(field)
           ) {
             context.report({
               node: templateLiteral,

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -83,7 +83,13 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
           }
         }
       \`;
-    `
+    `,
+    {
+      code: `
+        graphql\`fragment Test on Page { id }\`;
+      `,
+      options: [{ignoreFields: ['id']}]
+    }
   ],
   invalid: [
     {
@@ -108,6 +114,13 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         graphql\`fragment Test on Page { unused1, unused2 }\`;
       `,
       errors: [unusedFieldsWarning('unused1'), unusedFieldsWarning('unused2')]
+    },
+    {
+      code: `
+        graphql\`fragment Test on Page { unused1, unused2 }\`;
+      `,
+      options: [{ignoreFields: ['unused1']}],
+      errors: [unusedFieldsWarning('unused2')]
     },
     {
       code: `

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -89,6 +89,14 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         graphql\`fragment Test on Page { id }\`;
       `,
       options: [{ignoreFields: ['id']}]
+    },
+    {
+      code: `
+        graphql\`fragment Test on Page { connection { edges { node { id } } } }\`;
+        const nodes = useConnectionArray(props.connection);
+        node.id;
+      `,
+      options: [{leavesOnly: true}]
     }
   ],
   invalid: [
@@ -114,6 +122,19 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
         graphql\`fragment Test on Page { unused1, unused2 }\`;
       `,
       errors: [unusedFieldsWarning('unused1'), unusedFieldsWarning('unused2')]
+    },
+    {
+      code: `
+        graphql\`fragment Test on Page { unused1 { unused2 } }\`;
+      `,
+      errors: [unusedFieldsWarning('unused1'), unusedFieldsWarning('unused2')]
+    },
+    {
+      code: `
+        graphql\`fragment Test on Page { unused1 { unused2 } }\`;
+      `,
+      options: [{leavesOnly: true}],
+      errors: [unusedFieldsWarning('unused2')]
     },
     {
       code: `


### PR DESCRIPTION
Builds on top of #94 for option parsing code. Check commit 8d0773f2e6822635629f6e01f32e0e67ff777670 only.

### Motivation

This makes it so we only check leave fields, I'm not sure if there is actually cases where checking non-leaves is useful, so I left it as an option. If there are not we could make this the default. There are cases where non leave fields are never accessed because of helper functions in other files.

For example I use a `useConnectionArray` hook to transform a connection to an array. This will currently trigger the unused field rule since the current file never accesses `edges` and `node`.

Example:

```js
graphql`fragment TestNested on Page { connection { edges { node { id } } } }`;
...
const nodes = useConnectionArray(props.connection);
...
nodes[0].id
```

### Test plan

Tested on a large relay codebase and added tests.