### PR TITLE
Fix crash when using dynamic import with must-colocate-fragment-spreads

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -150,7 +150,11 @@ function rule(context) {
     },
 
     ImportExpression(node) {
-      foundImportedModules.push(utils.getModuleName(node.source.value));
+      if (node.source.type === 'Literal') {
+        // Allow dynamic imports like import(`test/${fileName}`); and (path) => import(path);
+        // These would have node.source.value undefined
+        foundImportedModules.push(utils.getModuleName(node.source.value));
+      }
     },
 
     CallExpression(node) {

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -90,7 +90,17 @@ ruleTester.run(
       `,
       `
       graphql\`fragment foo on Page { ...Fragment @module(name: "ComponentName.react") }\`;
-      `
+      `,
+      '\
+      const getOperation = (reference) => {\
+        return import(`./src/__generated__/${reference}`);\
+      };\
+      ',
+      '\
+      const getOperation = (reference) => {\
+        return import(reference);\
+      };\
+      '
     ],
     invalid: [
       {


### PR DESCRIPTION
Using dynamic import like import() would cause a crash.

closes #99