### PR TITLE
[must-colocate-fragment-spreads] Handle importing relative index.js files which are direct siblings

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -108,6 +108,7 @@ function getGraphQLFragmentDefinitionName(graphQLAst) {
 function rule(context) {
   const foundImportedModules = [];
   const graphqlLiterals = [];
+  const contextFilename = context.getFilename();
 
   return {
     'Program:exit'(_node) {
@@ -145,7 +146,11 @@ function rule(context) {
 
     ImportDeclaration(node) {
       if (node.importKind === 'value') {
-        foundImportedModules.push(utils.getModuleName(node.source.value));
+        const moduleName = utils.getModuleName(
+          node.source.value,
+          contextFilename
+        );
+        foundImportedModules.push(moduleName);
       }
     },
 
@@ -153,7 +158,11 @@ function rule(context) {
       if (node.source.type === 'Literal') {
         // Allow dynamic imports like import(`test/${fileName}`); and (path) => import(path);
         // These would have node.source.value undefined
-        foundImportedModules.push(utils.getModuleName(node.source.value));
+        const moduleName = utils.getModuleName(
+          node.source.value,
+          contextFilename
+        );
+        foundImportedModules.push(moduleName);
       }
     },
 
@@ -163,7 +172,8 @@ function rule(context) {
       }
       const [source] = node.arguments;
       if (source && source.type === 'Literal') {
-        foundImportedModules.push(utils.getModuleName(source.value));
+        const moduleName = utils.getModuleName(source.value, contextFilename);
+        foundImportedModules.push(moduleName);
       }
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -67,7 +67,7 @@ function getLocFromIndex(sourceCode, index) {
 }
 
 // Copied directly from Relay
-function getModuleName(filePath) {
+function getModuleName(filePath, contextFilename) {
   // index.js -> index
   // index.js.flow -> index.js
   let filename = path.basename(filePath, path.extname(filePath));
@@ -79,6 +79,14 @@ function getModuleName(filePath) {
   // /path/to/button/index.js -> button
   let moduleName =
     filename === 'index' ? path.basename(path.dirname(filePath)) : filename;
+
+  // Special case to handle relative sibling index imports such as:
+  // import MyComponent from './'
+  if (moduleName === '.' && contextFilename) {
+    moduleName = path.basename(
+      path.dirname(path.join(moduleName, contextFilename))
+    );
+  }
 
   // foo-bar -> fooBar
   // Relay compatibility mode splits on _, so we can't use that here.

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -100,7 +100,16 @@ ruleTester.run(
       const getOperation = (reference) => {\
         return import(reference);\
       };\
-      '
+      ',
+      {
+        filename: '/Container/MyComponent/AnotherComponent.js',
+        code: `
+        import MyComponent from './';
+        graphql\`fragment foo on Page {
+          ...MyComponent_foo
+        }\`;
+      `
+      }
     ],
     invalid: [
       {
@@ -152,6 +161,16 @@ ruleTester.run(
         }\`;
         `,
         errors: [unusedFieldsWarning('component_fragment')]
+      },
+      {
+        filename: '/Container/NotMyComponent/AnotherComponent.js',
+        code: `
+        import MyComponent from './';
+        graphql\`fragment foo on Page {
+          ...MyComponent_foo
+        }\`;
+      `,
+        errors: [unusedFieldsWarning('MyComponent_foo')]
       }
     ]
   }


### PR DESCRIPTION
If you import a component that is a direct sibling (in the same directory) using the ./index.js shorthand (`.`, `./`, etc.) the rule currently fails, as the module parsing returns an empty string.

given the code:
```-js
import MyComponent from './'

graphql`
  ...MyComponent_foo
`
```
The ImportDeclaration parsing fails to understand this relative shorthand:
```-js
  let moduleName =
    filename === 'index' ? path.basename(path.dirname(filePath)) : filename;
```
Here `moduleName` becomes simply `.`.

My approach is to, in that case, parse the context filename to get out the parent directory. It's perhaps questionable since it means changing a util that is marked as "Copied directly from relay", but it's clear that this plugin is failing where Relay does not - namely in correctly resolving the relative import.

I'm open to better ways to fix this, but it was flagged up swiftly after we tried installing this on our large codebase as it complained in many places (we use this pattern frequently) and the error message in those cases was confusing and inscrutable - ("...but it IS imported and used!").

I've added tests to check and to help elucidate the problem.