### PR TITLE
add "function-required-argument" rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ module.exports = {
     'relay/generated-flow-types': 'warn',
     'relay/must-colocate-fragment-spreads': 'warn',
     'relay/no-future-added-value': 'warn',
-    'relay/unused-fields': 'warn'
+    'relay/unused-fields': 'warn',
+    'relay/function-required-argument': 'warn',
+    'relay/hook-required-argument': 'warn'
   },
   plugins: ['relay']
 };

--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -16,6 +16,7 @@ module.exports = {
     'no-future-added-value': require('./src/rule-no-future-added-value'),
     'unused-fields': require('./src/rule-unused-fields'),
     'must-colocate-fragment-spreads': require('./src/rule-must-colocate-fragment-spreads'),
+    'function-required-argument': require('./src/rule-function-required-argument'),
     'hook-required-argument': require('./src/rule-hook-required-argument')
   },
   configs: {
@@ -28,6 +29,7 @@ module.exports = {
         'relay/no-future-added-value': 'warn',
         'relay/unused-fields': 'warn',
         'relay/must-colocate-fragment-spreads': 'warn',
+        'relay/function-required-argument': 'warn',
         'relay/hook-required-argument': 'warn'
       }
     },
@@ -40,6 +42,7 @@ module.exports = {
         'relay/no-future-added-value': 'error',
         'relay/unused-fields': 'error',
         'relay/must-colocate-fragment-spreads': 'error',
+        'relay/function-required-argument': 'error',
         'relay/hook-required-argument': 'error'
       }
     }

--- a/src/rule-function-required-argument.js
+++ b/src/rule-function-required-argument.js
@@ -7,8 +7,7 @@
 
 'use strict';
 
-const utils = require('./utils');
-const shouldLint = utils.shouldLint;
+const {shouldLint} = require('./utils');
 
 function reportMissingKeyArgument(node, context) {
   context.report({

--- a/src/rule-function-required-argument.js
+++ b/src/rule-function-required-argument.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const utils = require('./utils');
+const shouldLint = utils.shouldLint;
+
+function reportMissingKeyArgument(node, context) {
+  context.report({
+    node: node,
+    message: `A fragment reference should be passed to the \`readInlineData\` function`
+  });
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Validates that the second argument is passed to relay functions.'
+    }
+  },
+  create(context) {
+    if (!shouldLint(context)) {
+      return {};
+    }
+
+    return {
+      'CallExpression[callee.name=readInlineData][arguments.length < 2]'(node) {
+        reportMissingKeyArgument(node, context);
+      }
+    };
+  }
+};

--- a/test/function-required-argument.js
+++ b/test/function-required-argument.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const rules = require('..').rules;
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+});
+
+ruleTester.run(
+  'function-required-argument',
+  rules['function-required-argument'],
+  {
+    valid: [
+      {
+        code: `
+       import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+       readInlineData(graphql\`fragment TestFragment_foo on User { id }\`, ref)
+     `
+      }
+    ],
+    invalid: [
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        readInlineData(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message:
+              'A fragment reference should be passed to the `readInlineData` function',
+            line: 3
+          }
+        ]
+      }
+    ]
+  }
+);


### PR DESCRIPTION
Following https://github.com/relayjs/eslint-plugin-relay/issues/106 issue.

This change adds new rule to check missing argument for `readInlineData` function call. Docs https://relay.dev/docs/en/graphql-in-relay#inline

Also updates `.eslintrc.js` example in readme.