### PR TITLE
Add eslint disable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,24 @@ Add `plugin:relay/recommended` or `plugin:relay/strict` in `extends`:
 }
 ```
 
+### Suppressing rules within graphql tags
+
+The following rules support suppression within graphql tags:
+
+- relay/unused-fields
+- relay/must-colocate-fragment-spreads
+
+Supported rules can be suppressed by adding `# eslint-disable-next-line relay/name-of-rule` to the preceding line:
+
+```js
+graphql`fragment foo on Page {
+  # eslint-disable-next-line relay/must-colocate-fragment-spreads
+  ...unused1
+}`
+```
+
+Note that only the `eslint-disable-next-line` form of suppression works. `eslint-disable-line` doesn't currently work until graphql-js provides support for [parsing Comment nodes](https://github.com/graphql/graphql-js/issues/2241) in their AST.
+
 ## Contribute
 
 We actively welcome pull requests, learn how to [contribute](./CONTRIBUTING.md).

--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -60,6 +60,9 @@
 const {visit} = require('graphql');
 const utils = require('./utils');
 
+const ESLINT_DISABLE_COMMENT =
+  ' eslint-disable-next-line relay/must-colocate-fragment-spreads';
+
 function getGraphQLFragmentSpreads(graphQLAst) {
   const fragmentSpreads = {};
   visit(graphQLAst, {
@@ -88,6 +91,11 @@ function getGraphQLFragmentSpreads(graphQLAst) {
             }
           }
         }
+      }
+      if (
+        utils.hasPrecedingEslintDisableComment(node, ESLINT_DISABLE_COMMENT)
+      ) {
+        return;
       }
       fragmentSpreads[node.name.value] = node;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -112,6 +112,11 @@ function shouldLint(context) {
   return /graphql|relay/i.test(context.getSourceCode().text);
 }
 
+function hasPrecedingEslintDisableComment(node, commentText) {
+  const prevNode = node.loc.startToken.prev;
+  return prevNode.kind === 'Comment' && prevNode.value.startsWith(commentText);
+}
+
 module.exports = {
   isGraphQLTemplate: isGraphQLTemplate,
   getGraphQLAST: getGraphQLAST,
@@ -119,6 +124,7 @@ module.exports = {
   getLocFromIndex: getLocFromIndex,
   getModuleName: getModuleName,
   getRange: getRange,
+  hasPrecedingEslintDisableComment: hasPrecedingEslintDisableComment,
   isGraphQLTag: isGraphQLTag,
   isGraphQLDeprecatedTag: isGraphQLDeprecatedTag,
   shouldLint: shouldLint

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -100,7 +100,13 @@ ruleTester.run(
       const getOperation = (reference) => {\
         return import(reference);\
       };\
-      '
+      ',
+      `
+      graphql\`fragment foo on Page {
+        # eslint-disable-next-line relay/must-colocate-fragment-spreads
+        ...unused1
+      }\`;
+      `
     ],
     invalid: [
       {

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -83,6 +83,12 @@ ruleTester.run('unused-fields', rules['unused-fields'], {
           }
         }
       \`;
+    `,
+    `
+      graphql\`fragment foo on Page {
+        # eslint-disable-next-line relay/unused-fields
+        name
+      }\`;
     `
   ],
   invalid: [


### PR DESCRIPTION
This PR adds the ability to suppress eslint reporting within graphql tags:

```js
graphql`
  fragment foo on Page {
    # eslint-disable-next-line relay/must-colocate-fragment-spreads
    ...unused1
  }
`
```

Note that only the `eslint-disable-next-line` form of suppression works. `eslint-disable-line` doesn't currently work until graphql-js provides support for [parsing Comment nodes](https://github.com/graphql/graphql-js/issues/2241) in their AST.
