### PR TITLE
Require flow type in useMutation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-relay",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "ESLint plugin for Relay.",
   "main": "eslint-plugin-relay",
   "repository": "relayjs/eslint-plugin-relay",

--- a/src/rule-generated-flow-types.js
+++ b/src/rule-generated-flow-types.js
@@ -565,6 +565,24 @@ module.exports = {
       },
 
       /**
+       * Find useMutation() calls without type arguments.
+       */
+      'CallExpression[callee.name=useMutation]:not([typeArguments])'(node) {
+        const queryName = getDefinitionName(node.arguments[0]);
+        context.report({
+          node,
+          message: `The \`useMutation\` hook should be used with an explicit generated Flow type, e.g.: useMutation<{{queryName}}>(...)`,
+          data: {
+            queryName: queryName
+          },
+          fix:
+            queryName != null && options.fix
+              ? createTypeImportFixer(node, queryName, queryName)
+              : null
+        });
+      },
+
+      /**
        * Find usePaginationFragment() calls without type arguments.
        */
       'CallExpression[callee.name=usePaginationFragment]:not([typeArguments])'(

--- a/test/test.js
+++ b/test/test.js
@@ -902,6 +902,21 @@ import type {FooQuery} from './__generated__/FooQuery.graphql'
       output: null
     },
     {
+      code: `\nconst mutation = graphql\`mutation FooMutation { id }\`;\nconst [commit] = useMutation(mutation);`,
+      options: DEFAULT_OPTIONS,
+      errors: [
+        {
+          message:
+            'The `useMutation` hook should be used with an explicit generated Flow type, e.g.: useMutation<FooMutation>(...)',
+          line: 3
+        }
+      ],
+      output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+const mutation = graphql\`mutation FooMutation { id }\`;
+const [commit] = useMutation<FooMutation>(mutation);`
+    },
+    {
       code: `\ncommitMutation(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`,
       errors: [
         {


### PR DESCRIPTION
This PR adds a lint rule and autofix for `useMutation` without a flow type parameter.
