### PR TITLE
Remove RelayCompat support

### DIFF
--- a/src/rule-graphql-naming.js
+++ b/src/rule-graphql-naming.js
@@ -13,7 +13,6 @@ const getLoc = utils.getLoc;
 const getModuleName = utils.getModuleName;
 const getRange = utils.getRange;
 const isGraphQLTag = utils.isGraphQLTag;
-const isGraphQLDeprecatedTag = utils.isGraphQLDeprecatedTag;
 const shouldLint = utils.shouldLint;
 
 const CREATE_CONTAINER_FUNCTIONS = new Set([
@@ -148,10 +147,7 @@ module.exports = {
               property.computed === false &&
               property.value.type === 'TaggedTemplateExpression'
             ) {
-              if (
-                !isGraphQLTag(property.value.tag) &&
-                !isGraphQLDeprecatedTag(property.value.tag)
-              ) {
+              if (!isGraphQLTag(property.value.tag)) {
                 context.report({
                   node: property.value.tag,
                   message:

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,10 +104,6 @@ function isGraphQLTag(tag) {
   return tag.type === 'Identifier' && tag.name === 'graphql';
 }
 
-function isGraphQLDeprecatedTag(tag) {
-  return tag.type === 'Identifier' && tag.name === 'graphql_DEPRECATED';
-}
-
 function shouldLint(context) {
   return /graphql|relay/i.test(context.getSourceCode().text);
 }
@@ -126,6 +122,5 @@ module.exports = {
   getRange: getRange,
   hasPrecedingEslintDisableComment: hasPrecedingEslintDisableComment,
   isGraphQLTag: isGraphQLTag,
-  isGraphQLDeprecatedTag: isGraphQLDeprecatedTag,
   shouldLint: shouldLint
 };

--- a/test/test.js
+++ b/test/test.js
@@ -47,12 +47,6 @@ const valid = [
     code: `createFragmentContainer(Component, {
       user: graphql\`fragment MyComponent_user on User {id}\`,
     });`
-  },
-  {
-    filename: 'path/to/MyDeprecatedComponent.jsx',
-    code: `createFragmentContainer(Component, {
-      user: graphql_DEPRECATED\`fragment MyComponent_user on User {id}\`,
-    });`
   }
 ];
 


### PR DESCRIPTION
The `graphql_DEPRECATED` tag was used for RelayCompat which was long
deleted in OSS as well as internally. Cleans up a bit of code from the
linter.