### PR TITLE
Add "generated-typescript-types" rule, and "ts-recommended"

### DIFF
--- a/eslint-plugin-relay.js
+++ b/eslint-plugin-relay.js
@@ -58,7 +58,7 @@ module.exports = {
         'relay/must-colocate-fragment-spreads': 'error',
         'relay/function-required-argument': 'error',
         'relay/hook-required-argument': 'error'
-      },
+      }
     },
     'ts-strict': {
       rules: {
@@ -71,7 +71,7 @@ module.exports = {
         'relay/must-colocate-fragment-spreads': 'error',
         'relay/function-required-argument': 'error',
         'relay/hook-required-argument': 'error'
-      },
-    },
+      }
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
     "graphql": "^14.0.0 || ^15.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/parser": "^5.4.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^7.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^9.1.3",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "typescript": "^4.5.2"
   }
 }

--- a/src/rule-generated-typescript-types.js
+++ b/src/rule-generated-typescript-types.js
@@ -437,13 +437,13 @@ module.exports = {
       const queryName = getRefetchableQueryName(node.arguments[0]);
       context.report({
         node: node,
-        message: `The \`${hookName}\` hook should be used with an explicit generated Typescript type, e.g.: ${hookName}<{{queryName}}, _>(...)`,
+        message: `The \`${hookName}\` hook should be used with an explicit generated Typescript type, e.g.: ${hookName}<{{queryName}}>(...)`,
         data: {
           queryName: queryName || defaultQueryName
         },
         fix:
           queryName != null && options.fix
-            ? createTypeImportFixer(node, queryName, `${queryName}, _`)
+            ? createTypeImportFixer(node, queryName, `${queryName}`)
             : null
       });
     }

--- a/test/generated-typescript-types.js
+++ b/test/generated-typescript-types.js
@@ -57,7 +57,7 @@ ruleTester.run(
       {
         code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `
       },
       {
@@ -73,19 +73,19 @@ ruleTester.run(
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
 
         const {data: ref} = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
-        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
       `
       },
       {
         code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        useBlockingPaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `
       },
       {
         code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        useLegacyPaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `
       },
       {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
@@ -272,7 +272,7 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
         errors: [
           {
             message:
-              'The `useRefetchableFragment` hook should be used with an explicit generated Typescript type, e.g.: useRefetchableFragment<TestFragmentQuery, _>(...)',
+              'The `useRefetchableFragment` hook should be used with an explicit generated Typescript type, e.g.: useRefetchableFragment<TestFragmentQuery>(...)',
             line: 3,
             column: 9
           }
@@ -281,12 +281,12 @@ The prop passed to useFragment() should be typed with the type 'TestFragment_foo
         output: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
 import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
-        useRefetchableFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName:"TestFragmentQuery") { id }\`)
+        useRefetchableFragment<TestFragmentQuery>(graphql\`fragment TestFragment_foo on User @refetchable(queryName:"TestFragmentQuery") { id }\`)
       `
       },
       {
         code: `
-        useRefetchableFragment<RefetchQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        useRefetchableFragment<RefetchQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
         errors: [
           {
@@ -308,7 +308,7 @@ The prop passed to useRefetchableFragment() should be typed with the type 'TestF
         errors: [
           {
             message:
-              'The `usePaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: usePaginationFragment<TestFragmentQuery, _>(...)',
+              'The `usePaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: usePaginationFragment<TestFragmentQuery>(...)',
             line: 3,
             column: 9
           }
@@ -316,12 +316,12 @@ The prop passed to useRefetchableFragment() should be typed with the type 'TestF
         output: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
 import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
-        usePaginationFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
+        usePaginationFragment<TestFragmentQuery>(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
       `
       },
       {
         code: `
-        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
         errors: [
           {
@@ -339,7 +339,7 @@ The prop passed to usePaginationFragment() should be typed with the type 'TestFr
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
 
         const refUnused = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
-        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
       `,
         errors: [
           {
@@ -357,7 +357,7 @@ The prop passed to usePaginationFragment() should be typed with the type 'TestPa
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
 
         const {data: refUnused }= useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
-        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
       `,
         errors: [
           {
@@ -378,7 +378,7 @@ The prop passed to usePaginationFragment() should be typed with the type 'TestPa
         errors: [
           {
             message:
-              'The `useBlockingPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useBlockingPaginationFragment<TestFragmentQuery, _>(...)',
+              'The `useBlockingPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useBlockingPaginationFragment<TestFragmentQuery>(...)',
             line: 3,
             column: 9
           }
@@ -386,7 +386,7 @@ The prop passed to usePaginationFragment() should be typed with the type 'TestPa
       },
       {
         code: `
-        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        useBlockingPaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
         errors: [
           {
@@ -409,7 +409,7 @@ The prop passed to useBlockingPaginationFragment() should be typed with the type
         errors: [
           {
             message:
-              'The `useLegacyPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useLegacyPaginationFragment<PaginationQuery, _>(...)',
+              'The `useLegacyPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useLegacyPaginationFragment<PaginationQuery>(...)',
             line: 3,
             column: 9
           }
@@ -418,7 +418,7 @@ The prop passed to useBlockingPaginationFragment() should be typed with the type
       },
       {
         code: `
-        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+        useLegacyPaginationFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
       `,
         errors: [
           {

--- a/test/generated-typescript-types.js
+++ b/test/generated-typescript-types.js
@@ -1,0 +1,1567 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const rules = require('..').rules;
+const RuleTester = require('eslint').RuleTester;
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}
+});
+
+const HAS_ESLINT_BEEN_UPGRADED_YET = false;
+const DEFAULT_OPTIONS = [
+  {
+    fix: true,
+    haste: false
+  }
+];
+
+ruleTester.run(
+  'generated-typescript-types',
+  rules['generated-typescript-types'],
+  {
+    valid: [
+      // syntax error, covered by `graphql-syntax`
+      {code: 'graphql`query {{{`'},
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import {type TestFragment_foo$key} from './path/to/TestFragment_foo.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useRefetchableFragment<PaginationQuery>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+
+        const ref = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+        usePaginationFragment<PaginationQuery>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+
+        const {data: ref} = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `
+      },
+      {code: 'useQuery<Foo>(graphql`query Foo { id }`)'},
+      {code: 'useLazyLoadQuery<Foo>(graphql`query Foo { id }`)'},
+      {
+        code: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user as User} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: User}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {
+          user: MyComponent_user,
+        }
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_double_underscore} from 'MyComponent_double_underscore.graphql'
+        type Props = {
+          double_underscore: MyComponent_double_underscore,
+        }
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          double_underscore: graphql\`fragment MyComponent_double_underscore on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {
+          readonly user: MyComponent_user,
+        }
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {
+          user?: MyComponent_user,
+        }
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {
+          user: MyComponent_user,
+        }
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      },
+      {
+        code: `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {
+          user: MyComponent_user,
+        }
+        type State = {
+          count: number,
+        }
+
+        class MyComponent extends React.Component<Props, State> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+      }
+    ],
+    invalid: [
+      {
+        // imports TestFragment_other$key instead of TestFragment_foo$key
+        code: `
+        import type {TestFragment_other$key} from './path/to/TestFragment_other.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 3,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {other} from 'TestFragment_foo.graphql';
+        useFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to useFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 3,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useRefetchableFragment(graphql\`fragment TestFragment_foo on User @refetchable(queryName:"TestFragmentQuery") { id }\`)
+      `,
+        errors: [
+          {
+            message:
+              'The `useRefetchableFragment` hook should be used with an explicit generated Typescript type, e.g.: useRefetchableFragment<TestFragmentQuery, _>(...)',
+            line: 3,
+            column: 9
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
+        useRefetchableFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName:"TestFragmentQuery") { id }\`)
+      `
+      },
+      {
+        code: `
+        useRefetchableFragment<RefetchQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to useRefetchableFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 2,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        usePaginationFragment(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
+      `,
+        options: DEFAULT_OPTIONS,
+        errors: [
+          {
+            message:
+              'The `usePaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: usePaginationFragment<TestFragmentQuery, _>(...)',
+            line: 3,
+            column: 9
+          }
+        ],
+        output: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
+        usePaginationFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
+      `
+      },
+      {
+        code: `
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to usePaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 2,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+
+        const refUnused = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
+
+  import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
+            line: 5,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+
+        const {data: refUnused }= useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+        usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
+
+  import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
+            line: 5,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useBlockingPaginationFragment(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
+      `,
+        errors: [
+          {
+            message:
+              'The `useBlockingPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useBlockingPaginationFragment<TestFragmentQuery, _>(...)',
+            line: 3,
+            column: 9
+          }
+        ]
+      },
+      {
+        code: `
+        useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to useBlockingPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 2,
+            column: 9
+          }
+        ]
+      },
+
+      {
+        code: `
+        import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+        useLegacyPaginationFragment(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        options: DEFAULT_OPTIONS,
+        errors: [
+          {
+            message:
+              'The `useLegacyPaginationFragment` hook should be used with an explicit generated Typescript type, e.g.: useLegacyPaginationFragment<PaginationQuery, _>(...)',
+            line: 3,
+            column: 9
+          }
+        ],
+        output: null
+      },
+      {
+        code: `
+        useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+      `,
+        errors: [
+          {
+            message: `
+The prop passed to useLegacyPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+
+  import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+            line: 2,
+            column: 9
+          }
+        ]
+      },
+
+      {
+        code: `\nuseQuery(graphql\`query FooQuery { id }\`)`,
+        errors: [
+          {
+            message:
+              'The `useQuery` hook should be used with an explicit generated Typescript type, e.g.: useQuery<FooQuery>(...)',
+            line: 2,
+            column: 1
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooQuery} from './__generated__/FooQuery.graphql'
+useQuery<FooQuery>(graphql\`query FooQuery { id }\`)`
+      },
+      {
+        code: `
+        const query = graphql\`query FooQuery { id }\`;
+        const query2 = query;
+        useQuery(query2);
+      `,
+        errors: [
+          {
+            message:
+              'The `useQuery` hook should be used with an explicit generated Typescript type, e.g.: useQuery<FooQuery>(...)',
+            line: 4
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooQuery} from './__generated__/FooQuery.graphql'
+        const query = graphql\`query FooQuery { id }\`;
+        const query2 = query;
+        useQuery<FooQuery>(query2);
+      `
+      },
+      {
+        code: `
+        const query = 'graphql';
+        useQuery(query);
+      `,
+        options: DEFAULT_OPTIONS,
+        errors: [
+          {
+            message:
+              'The `useQuery` hook should be used with an explicit generated Typescript type, e.g.: useQuery<ExampleQuery>(...)',
+            line: 3
+          }
+        ],
+        output: null
+      },
+
+      {
+        code: `\nuseLazyLoadQuery(graphql\`query FooQuery { id }\`)`,
+        errors: [
+          {
+            message:
+              'The `useLazyLoadQuery` hook should be used with an explicit generated Typescript type, e.g.: useLazyLoadQuery<FooQuery>(...)',
+            line: 2,
+            column: 1
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooQuery} from './__generated__/FooQuery.graphql'
+useLazyLoadQuery<FooQuery>(graphql\`query FooQuery { id }\`)`
+      },
+      {
+        code: `
+        const query = graphql\`query FooQuery { id }\`;
+        const query2 = query;
+        useLazyLoadQuery(query2);
+      `,
+        errors: [
+          {
+            message:
+              'The `useLazyLoadQuery` hook should be used with an explicit generated Typescript type, e.g.: useLazyLoadQuery<FooQuery>(...)',
+            line: 4
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooQuery} from './__generated__/FooQuery.graphql'
+        const query = graphql\`query FooQuery { id }\`;
+        const query2 = query;
+        useLazyLoadQuery<FooQuery>(query2);
+      `
+      },
+      {
+        code: `
+        const query = 'graphql';
+        useLazyLoadQuery(query);
+      `,
+        options: DEFAULT_OPTIONS,
+        errors: [
+          {
+            message:
+              'The `useLazyLoadQuery` hook should be used with an explicit generated Typescript type, e.g.: useLazyLoadQuery<ExampleQuery>(...)',
+            line: 3
+          }
+        ],
+        output: null
+      },
+      {
+        code: `\nconst mutation = graphql\`mutation FooMutation { id }\`;\nconst [commit] = useMutation(mutation);`,
+        options: DEFAULT_OPTIONS,
+        errors: [
+          {
+            message:
+              'The `useMutation` hook should be used with an explicit generated Typescript type, e.g.: useMutation<FooMutation>(...)',
+            line: 3
+          }
+        ],
+        output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+const mutation = graphql\`mutation FooMutation { id }\`;
+const [commit] = useMutation<FooMutation>(mutation);`
+      },
+      {
+        code: `\ncommitMutation(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`,
+        errors: [
+          {
+            message:
+              'The `commitMutation` must be used with an explicit generated Typescript type, e.g.: commitMutation<FooMutation>(...)',
+            line: 2,
+            column: 1
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+commitMutation<FooMutation>(environemnt, {mutation: graphql\`mutation FooMutation { id }\`})`
+      },
+      {
+        code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation(environment, {mutation});
+      `,
+        errors: [
+          {
+            message:
+              'The `commitMutation` must be used with an explicit generated Typescript type, e.g.: commitMutation<FooMutation>(...)',
+            line: 3
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        commitMutation<FooMutation>(environment, {mutation});
+      `
+      },
+      {
+        code: `
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation(environment, {mutation: myMutation});
+      `,
+        errors: [
+          {
+            message:
+              'The `commitMutation` must be used with an explicit generated Typescript type, e.g.: commitMutation<FooMutation>(...)',
+            line: 4
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooMutation} from './__generated__/FooMutation.graphql'
+        const mutation = graphql\`mutation FooMutation { id }\`;
+        const myMutation = mutation;
+        commitMutation<FooMutation>(environment, {mutation: myMutation});
+      `
+      },
+      {
+        code: `\nrequestSubscription(environemnt, {subscription: graphql\`subscription FooSubscription { id }\`})`,
+        errors: [
+          {
+            message:
+              'The `requestSubscription` must be used with an explicit generated Typescript type, e.g.: requestSubscription<FooSubscription>(...)',
+            line: 2,
+            column: 1
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+requestSubscription<FooSubscription>(environemnt, {subscription: graphql\`subscription FooSubscription { id }\`})`
+      },
+      {
+        code: `
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        requestSubscription(environment, {subscription});
+      `,
+        errors: [
+          {
+            message:
+              'The `requestSubscription` must be used with an explicit generated Typescript type, e.g.: requestSubscription<FooSubscription>(...)',
+            line: 3
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        requestSubscription<FooSubscription>(environment, {subscription});
+      `
+      },
+      {
+        code: `
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        const mySubscription = subscription;
+        requestSubscription(environment, {subscription: mySubscription});
+      `,
+        errors: [
+          {
+            message:
+              'The `requestSubscription` must be used with an explicit generated Typescript type, e.g.: requestSubscription<FooSubscription>(...)',
+            line: 4
+          }
+        ],
+        options: DEFAULT_OPTIONS,
+        output: `
+import type {FooSubscription} from './__generated__/FooSubscription.graphql'
+        const subscription = graphql\`subscription FooSubscription { id }\`;
+        const mySubscription = subscription;
+        requestSubscription<FooSubscription>(environment, {subscription: mySubscription});
+      `
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component<{}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or ' +
+              'it is not marked with the generated typescript type ' +
+              '`MyComponent_user`. See ' +
+              'https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'Profile.js',
+        code: `
+        type Props = {
+          user: {
+            id: number,
+          } | undefined | null,
+        };
+        class Profile extends React.Component<Props> {}
+        createFragmentContainer(Profile, {
+          user: graphql\`
+            fragment Profile_user on User {
+              id
+            }
+          \`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`Profile_user` typescript type. See ' +
+              'https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 7,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component<{somethingElse: number}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user, somethingElse: number}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `MyComponent_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component<{user: number}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'path/to/Example.js',
+        // Test multiple layers of intersection types.
+        code: `
+        type Props = {} & {};
+        type MergedProps = {} & Props;
+        class Example extends React.PureComponent<MergedProps> {
+        }
+        module.exports = createFragmentContainer(Example, {
+          user: graphql\`fragment Example_user on User { id }\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `Example_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component<{user: Random_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type Props = {};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `MyComponent_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type Props = {somethingElse: number};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        type Props = {user: MyComponent_user, somethingElse: number};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `MyComponent_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type Props = {user: number};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type Props = {user: Random_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: DEFAULT_OPTIONS,
+        output: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        options: [{haste: true}],
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {MyComponent_user} from 'MyComponent_user.graphql'
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 2,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import type aaa from 'aaa'
+        import type zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type aaa from 'aaa'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type zzz from 'zzz'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 5,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import type {aaa} from 'aaa'
+        import type zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {aaa} from 'aaa'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type zzz from 'zzz'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 5,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 5,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        const aaa = require('aaa')
+        const zzz = require('zzz')
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        const aaa = require('aaa')
+        const zzz = require('zzz')
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 5,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        const aaa = require('aaa')
+
+        import zzz from 'zzz'
+
+        import type ccc from 'ccc'
+        import type {xxx} from 'xxx'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        const aaa = require('aaa')
+
+        import zzz from 'zzz'
+
+        import type ccc from 'ccc'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        import type {xxx} from 'xxx'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 9,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+
+        class MyComponent extends React.Component {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import {aaa} from 'aaa'
+        import zzz from 'zzz'
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+
+        type Props = {user: MyComponent_user};
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 5,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        import type {MyComponent_user as User} from 'aaa'
+
+        class MyComponent extends React.Component<{ user: MyComponent_user }> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {MyComponent_user as User} from 'aaa'
+
+        class MyComponent extends React.Component<{ user: User }> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`User` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 4,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type OtherProps = {
+          other: string
+        }
+
+        type Props = {
+          user: any | null | undefined,
+        } & OtherProps;
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        output: HAS_ESLINT_BEEN_UPGRADED_YET
+          ? `
+        import type {MyComponent_user} from './__generated__/MyComponent_user.graphql'
+        class MyComponent extends React.Component<{user: MyComponent_user}> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `
+          : null,
+        errors: [
+          {
+            message:
+              'Component property `user` expects to use the generated ' +
+              '`MyComponent_user` typescript type. See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 10,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type RelayProps = {
+          user: string
+        }
+
+        type Props = {
+          other: any | null | undefined,
+        } & RelayProps;
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `MyComponent_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 10,
+            column: 15
+          }
+        ]
+      },
+      {
+        filename: 'MyComponent.jsx',
+        code: `
+        type RelayProps = {
+          users: MyComponent_user
+        }
+
+        type Props = {
+          other: any | string | undefined,
+        } & RelayProps
+
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div />;
+          }
+        }
+
+        createFragmentContainer(MyComponent, {
+          user: graphql\`fragment MyComponent_user on User {id}\`,
+        });
+      `,
+        errors: [
+          {
+            message:
+              '`user` is not declared in the `props` of the React component or it is not marked with the generated typescript type `MyComponent_user`. ' +
+              'See https://facebook.github.io/relay/docs/en/graphql-in-relay.html#importing-generated-definitions',
+            line: 10,
+            column: 15
+          }
+        ]
+      }
+    ]
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,6 +135,71 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
+
+"@typescript-eslint/parser@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.4.0.tgz#3aa83ce349d66e39b84151f6d5464928044ca9e3"
+  integrity sha512-JoB41EmxiYpaEsRwpZEYAJ9XQURPFer8hpkIW9GiaspVLX8oqbqNM8P4EP8HOZg96yaALiLEVWllA2E8vwsIKw==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.4.0"
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/typescript-estree" "5.4.0"
+    debug "^4.3.2"
+
+"@typescript-eslint/scope-manager@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.4.0.tgz#aaab08415f4a9cf32b870c7750ae8ba4607126a1"
+  integrity sha512-pRxFjYwoi8R+n+sibjgF9iUiAELU9ihPBtHzocyW8v8D8G8KeQvXTsW7+CBYIyTYsmhtNk50QPGLE3vrvhM5KA==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/visitor-keys" "5.4.0"
+
+"@typescript-eslint/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.4.0.tgz#b1c130f4b381b77bec19696c6e3366f9781ce8f2"
+  integrity sha512-GjXNpmn+n1LvnttarX+sPD6+S7giO+9LxDIGlRl4wK3a7qMWALOHYuVSZpPTfEIklYjaWuMtfKdeByx0AcaThA==
+
+"@typescript-eslint/typescript-estree@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.4.0.tgz#fe524fb308973c68ebeb7428f3b64499a6ba5fc0"
+  integrity sha512-nhlNoBdhKuwiLMx6GrybPT3SFILm5Gij2YBdPEPFlYNFAXUJWX6QRgvi/lwVoadaQEFsizohs6aFRMqsXI2ewA==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    "@typescript-eslint/visitor-keys" "5.4.0"
+    debug "^4.3.2"
+    globby "^11.0.4"
+    is-glob "^4.0.3"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/visitor-keys@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.4.0.tgz#09bc28efd3621f292fe88c86eef3bf4893364c8c"
+  integrity sha512-PVbax7MeE7tdLfW5SA0fs8NGVVr+buMPrcj+CWYWPXsZCH8qZ1THufDzbXm1xrZ2b2PA1iENJ0sRq5fuUtvsJg==
+  dependencies:
+    "@typescript-eslint/types" "5.4.0"
+    eslint-visitor-keys "^3.0.0"
+
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
@@ -214,6 +279,11 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
 astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
@@ -249,7 +319,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -350,7 +420,7 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4.3.2, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -371,6 +441,13 @@ diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -444,6 +521,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz#eee4acea891814cda67a7d8812d9647dd0179af2"
+  integrity sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==
 
 eslint@^7.8.0:
   version "7.32.0"
@@ -544,6 +626,17 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.1.1:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -553,6 +646,13 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastq@^1.6.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
+  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  dependencies:
+    reusify "^1.0.4"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -667,6 +767,18 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
+globby@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
+  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.1.1"
+    ignore "^5.1.4"
+    merge2 "^1.3.0"
+    slash "^3.0.0"
+
 "graphql@^14.0.0 || ^15.0.0":
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
@@ -703,6 +815,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.4:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.9.tgz#9ec1a5cbe8e1446ec60d4420060d43aa6e7382fb"
+  integrity sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==
 
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.3.0"
@@ -754,7 +871,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -860,6 +977,19 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+merge2@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
 
 minimatch@3.0.4, minimatch@^3.0.4:
   version "3.0.4"
@@ -983,7 +1113,12 @@ path-parse@^1.0.6:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
@@ -1014,6 +1149,11 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -1057,6 +1197,11 @@ resolve@^1.12.0:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
+reusify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
+  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1064,12 +1209,19 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
 safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-semver@^7.2.1:
+semver@^7.2.1, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -1094,6 +1246,11 @@ shebang-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -1184,6 +1341,18 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tslib@^1.8.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
+  dependencies:
+    tslib "^1.8.1"
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -1195,6 +1364,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Based heavily on #115, thanks @llldar to do the ground work.

Note that #119 is a different way of fixing the same underlying issue. 
I wanted to open this PR either way, because it's a different way of getting to a solution (Please feel free to choose whatever is considered the better one!).

Notable differences between the two PR's: because this is a different file then the flow rule, this has (and can) leverage the AST returned from the @typescript-eslint/parser package. 
This let's us actually disable a workaround needed in flow (yay).

The test suit is mostly copied from `generated-flow-types`. Some test where changed / removed, because they don't really make sense in the TS world (imo anyhow).

There might be some shared code between the to `generated-XYZ-types` rules that could be extracted, I do want guidance here, as there also is a lot of code that is subtly different from the flow equivalent code (lot's of string token needed to be changed).

