### PR TITLE
[ci] Add release automation scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,16 @@ jobs:
       - name: Build latest (main) version
         if: github.ref == 'refs/heads/main'
         run: yarn version --no-git-tag-version --new-version 0.0.0-main-${GITHUB_SHA}
-      - name: Build release version
+      - name: Check release version matches tag
         if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-        run: yarn version --no-git-tag-version --new-version ${GITHUB_REF_NAME:1}
+        run: |
+          if [ $(cat package.json | jq -r '.version') != "${GITHUB_REF_NAME:1}" ]; then
+            echo "Version in package.json does not match tag. Did you forget to commit the package.json version bump?"
+            exit 1
+          fi
       - name: Publish to npm
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-        run: |
-          for pkg in dist/*; do
-            npm publish "$pkg" ${TAG}
-          done
+        run: npm publish ${TAG}
         env:
           TAG: ${{ github.ref == 'refs/heads/main' && '--tag=main' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,30 @@ jobs:
         run: yarn run lint
       - name: Prettier
         run: yarn run prettier-check
+
+  release:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.repository == 'relayjs/eslint-plugin-relay'
+    needs: [build, lint]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+      - name: Build latest (main) version
+        if: github.ref == 'refs/heads/main'
+        run: yarn version --no-git-tag-version --new-version 0.0.0-main-${GITHUB_SHA}
+      - name: Build release version
+        if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        run: yarn version --no-git-tag-version --new-version ${GITHUB_REF_NAME:1}
+      - name: Publish to npm
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+        run: |
+          for pkg in dist/*; do
+            npm publish "$pkg" ${TAG}
+          done
+        env:
+          TAG: ${{ github.ref == 'refs/heads/main' && '--tag=main' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,16 @@ _Before_ submitting a pull request, please make sure the following is done…
 4. Auto-format the code by running `yarn run prettier` or `npm run prettier`.
 5. If you haven't already, complete the CLA.
 
+### Package Publishing
+
+- Every change that gets pushed to the `main` branch will be published as `0.0.0-main-SHA`.
+- For stable releases, the release author is expected to update the version in `package.json`, commit that, and create an accompanying tag. Once this is pushed a package will be published following that version. The workflow would look something like this:
+
+  ```bash
+  $ yarn version --minor
+  $ git push --follow-tags
+  ```
+
 ### Contributor License Agreement (CLA)
 
 In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for another Facebook open source project, you're good to go. If you are submitting a pull request for the first time, just let us know that you have completed the CLA and we can cross-check with your GitHub username.


### PR DESCRIPTION
Ported from https://github.com/facebook/relay/blob/main/.github/workflows/ci.yml

* For each `main` push, this will publish a prerelease package that follows the format `0.0.0-main-SHA`
* For tag pushes it will publish a package that follows the name of the tag.

TODO:

- [ ] Set the `NPM_TOKEN` secret
- [ ] Test that both main and stable publishing works