### PR TITLE
Increase verbosity of npm publish from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           fi
       - name: Publish to npm
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
-        run: npm publish ${TAG}
+        run: npm publish --verbose ${TAG}
         env:
           TAG: ${{ github.ref == 'refs/heads/main' && '--tag=main' || ((contains(github.ref_name, '-rc.') && '--tag=dev') || '' )}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
This should help us debug what's going on, but also will allow us to retry with the newly created "Classic"/"Automation" token that I've setup.
![Screenshot 2023-11-27 at 1 48 53 PM](https://github.com/relayjs/eslint-plugin-relay/assets/162735/c860e799-7259-4490-b082-1bf3d52261cb)

For some reason rerunning the previously failed CI run is not available any more. I suspect rerunning expires at some point in time?
