### PR TITLE
Add registry-url to setup-node in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          registry-url: https://registry.npmjs.org/
           cache: 'yarn'
       - name: Build latest (main) version
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
I suspect this might be required to allow our authentication to work.

From the [setup-node docs](https://github.com/actions/setup-node/#usage):
```
    # Optional registry to set up for auth. Will set the registry in a project level .npmrc and .yarnrc file, 
    # and set up auth to read in from env.NODE_AUTH_TOKEN.
    # Default: ''
    registry-url: ''
```

Note this also mirrors what we do in the [Relay repo](https://github.com/facebook/relay/blob/05689b07f3415a028c6cbed8f3435d78690ebeb1/.github/workflows/ci.yml#L227C11-L227C52) where this flow seems to be working.