### PR TITLE
chore: update ci workflow actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -29,8 +29,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           cache: 'yarn'
@@ -47,8 +47,8 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'relayjs/eslint-plugin-relay'
     needs: [build, lint]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ The following rules support suppression within graphql tags:
 Supported rules can be suppressed by adding `# eslint-disable-next-line relay/name-of-rule` to the preceding line:
 
 ```js
-graphql`fragment foo on Page {
-  # eslint-disable-next-line relay/must-colocate-fragment-spreads
-  ...unused1
-}`
+graphql`
+  fragment foo on Page {
+    # eslint-disable-next-line relay/must-colocate-fragment-spreads
+    ...unused1
+  }
+`;
 ```
 
 Note that only the `eslint-disable-next-line` form of suppression works. `eslint-disable-line` doesn't currently work until graphql-js provides support for [parsing Comment nodes](https://github.com/graphql/graphql-js/issues/2241) in their AST.

--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
     "mocha": "^9.1.3",
     "prettier": "^2.4.1",
     "typescript": "^5.8.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/src/rule-generated-typescript-types.js
+++ b/src/rule-generated-typescript-types.js
@@ -351,7 +351,9 @@ module.exports = {
       }
       if (arg.type === 'Identifier') {
         const name = arg.name;
-        let scope = sourceCode.getScope ? sourceCode.getScope(arg) : context.getScope();
+        let scope = sourceCode.getScope
+          ? sourceCode.getScope(arg)
+          : context.getScope();
         while (scope != null) {
           for (const variable of scope.variables) {
             if (variable.name === name) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -45,7 +45,10 @@ function getLoc(context, templateNode, graphQLNode) {
   const start = startAndEnd[0];
   const end = startAndEnd[1];
   return {
-    start: getLocFromIndex(context.sourceCode ?? context.getSourceCode(), start),
+    start: getLocFromIndex(
+      context.sourceCode ?? context.getSourceCode(),
+      start
+    ),
     end: getLocFromIndex(context.sourceCode ?? context.getSourceCode(), end)
   };
 }
@@ -105,7 +108,9 @@ function isGraphQLTag(tag) {
 }
 
 function shouldLint(context) {
-  return /graphql|relay/i.test((context.sourceCode ?? context.getSourceCode()).text);
+  return /graphql|relay/i.test(
+    (context.sourceCode ?? context.getSourceCode()).text
+  );
 }
 
 function hasPrecedingEslintDisableComment(node, commentText) {

--- a/test/compat-uses-vars.js
+++ b/test/compat-uses-vars.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { builtinRules } = require('eslint/use-at-your-own-risk');
+const {builtinRules} = require('eslint/use-at-your-own-risk');
 const RuleTester = require('eslint').RuleTester;
 const rules = require('..').rules;
 
@@ -16,7 +16,7 @@ const ruleTester = new RuleTester({
   plugins: {
     relay: {
       rules: {
-        'compat-uses-vars': rules['compat-uses-vars'],
+        'compat-uses-vars': rules['compat-uses-vars']
       }
     }
   }

--- a/test/function-required-argument.js
+++ b/test/function-required-argument.js
@@ -11,7 +11,10 @@ const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
-  languageOptions: {ecmaVersion: 6, parser: require('@typescript-eslint/parser')}
+  languageOptions: {
+    ecmaVersion: 6,
+    parser: require('@typescript-eslint/parser')
+  }
 });
 
 ruleTester.run(

--- a/test/future-added-value.js
+++ b/test/future-added-value.js
@@ -17,8 +17,11 @@ const ruleTester = new RuleTester({
     ecmaVersion: 6,
     sourceType: 'module',
     parser: require('@babel/eslint-parser'),
-    parserOptions: { requireConfigFile: false, babelOptions: { "presets": ["@babel/preset-flow"] } }
-  },
+    parserOptions: {
+      requireConfigFile: false,
+      babelOptions: {presets: ['@babel/preset-flow']}
+    }
+  }
 });
 
 const FUTURE_ADDED_VALUE_MESSAGE =

--- a/test/generated-typescript-types.js
+++ b/test/generated-typescript-types.js
@@ -11,7 +11,11 @@ const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
-  languageOptions: {ecmaVersion: 6, parser: require('@typescript-eslint/parser'), parserOptions: {ecmaFeatures: {jsx: true}}},
+  languageOptions: {
+    ecmaVersion: 6,
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {ecmaFeatures: {jsx: true}}
+  }
 });
 
 const HAS_ESLINT_BEEN_UPGRADED_YET = false;

--- a/test/hook-required-argument.js
+++ b/test/hook-required-argument.js
@@ -11,7 +11,10 @@ const rules = require('..').rules;
 const RuleTester = require('eslint').RuleTester;
 
 const ruleTester = new RuleTester({
-  languageOptions: {ecmaVersion: 6, parser: require('@typescript-eslint/parser')}
+  languageOptions: {
+    ecmaVersion: 6,
+    parser: require('@typescript-eslint/parser')
+  }
 });
 
 ruleTester.run('hook-required-argument', rules['hook-required-argument'], {

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -13,7 +13,10 @@ const rules = require('..').rules;
 const RuleTester = eslint.RuleTester;
 
 const ruleTester = new RuleTester({
-  languageOptions: {ecmaVersion: 6, parser: require('@typescript-eslint/parser')}
+  languageOptions: {
+    ecmaVersion: 6,
+    parser: require('@typescript-eslint/parser')
+  }
 });
 
 function unusedFieldsWarning(fragment) {

--- a/test/test.js
+++ b/test/test.js
@@ -23,8 +23,11 @@ const ruleTester = new RuleTester({
     ecmaVersion: 6,
     sourceType: 'module',
     parser: require('@babel/eslint-parser'),
-    parserOptions: { requireConfigFile: false, babelOptions: { "presets": ["@babel/preset-flow", "@babel/preset-react"] } }
-  },
+    parserOptions: {
+      requireConfigFile: false,
+      babelOptions: {presets: ['@babel/preset-flow', '@babel/preset-react']}
+    }
+  }
 });
 
 const valid = [
@@ -629,21 +632,21 @@ import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
         useRefetchableFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName:"TestFragmentQuery") { id }\`)
       `
     },
-//     {
-//       code: `
-//         useRefetchableFragment<RefetchQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to useRefetchableFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
-//
-//   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
-//           line: 2,
-//           column: 9
-//         }
-//       ]
-//     },
+    //     {
+    //       code: `
+    //         useRefetchableFragment<RefetchQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to useRefetchableFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+    //           line: 2,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
     {
       code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
@@ -664,57 +667,57 @@ import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
         usePaginationFragment<TestFragmentQuery, _>(graphql\`fragment TestFragment_foo on User @refetchable(queryName: "TestFragmentQuery") { id }\`)
       `
     },
-//     {
-//       code: `
-//         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to usePaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
-//
-//   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
-//           line: 2,
-//           column: 9
-//         }
-//       ]
-//     },
-//     {
-//       code: `
-//         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-//
-//         const refUnused = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
-//         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
-//
-//   import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
-//           line: 5,
-//           column: 9
-//         }
-//       ]
-//     },
-//     {
-//       code: `
-//         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
-//
-//         const {data: refUnused }= useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
-//         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
-//
-//   import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
-//           line: 5,
-//           column: 9
-//         }
-//       ]
-//     },
+    //     {
+    //       code: `
+    //         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to usePaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+    //           line: 2,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
+    //     {
+    //       code: `
+    //         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+    //
+    //         const refUnused = useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+    //         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
+    //           line: 5,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
+    //     {
+    //       code: `
+    //         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
+    //
+    //         const {data: refUnused }= useFragment(graphql\`fragment TestFragment_foo on User { id }\`, props.user);
+    //         usePaginationFragment<PaginationQuery, _>(graphql\`fragment TestPaginationFragment_foo on User { id }\`, ref);
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to usePaginationFragment() should be typed with the type 'TestPaginationFragment_foo$key' imported from 'TestPaginationFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestPaginationFragment_foo$key} from 'TestPaginationFragment_foo.graphql';`.trim(),
+    //           line: 5,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
     {
       code: `
         import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';
@@ -729,21 +732,21 @@ import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
         }
       ]
     },
-//     {
-//       code: `
-//         useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to useBlockingPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
-//
-//   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
-//           line: 2,
-//           column: 9
-//         }
-//       ]
-//     },
+    //     {
+    //       code: `
+    //         useBlockingPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to useBlockingPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+    //           line: 2,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
 
     {
       code: `
@@ -761,21 +764,21 @@ import type {TestFragmentQuery} from './__generated__/TestFragmentQuery.graphql'
       ],
       output: null
     },
-//     {
-//       code: `
-//         useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
-//       `,
-//       errors: [
-//         {
-//           message: `
-// The prop passed to useLegacyPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
-//
-//   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
-//           line: 2,
-//           column: 9
-//         }
-//       ]
-//     },
+    //     {
+    //       code: `
+    //         useLegacyPaginationFragment<PaginationQuery, _>(graphql\`fragment TestFragment_foo on User { id }\`)
+    //       `,
+    //       errors: [
+    //         {
+    //           message: `
+    // The prop passed to useLegacyPaginationFragment() should be typed with the type 'TestFragment_foo$key' imported from 'TestFragment_foo.graphql', e.g.:
+    //
+    //   import type {TestFragment_foo$key} from 'TestFragment_foo.graphql';`.trim(),
+    //           line: 2,
+    //           column: 9
+    //         }
+    //       ]
+    //     },
 
     {
       code: `\nuseQuery(graphql\`query FooQuery { id }\`)`,

--- a/test/unused-fields.js
+++ b/test/unused-fields.js
@@ -13,7 +13,10 @@ const rules = require('..').rules;
 const RuleTester = eslint.RuleTester;
 
 const ruleTester = new RuleTester({
-  languageOptions: {ecmaVersion: 6, parser: require('@typescript-eslint/parser')}
+  languageOptions: {
+    ecmaVersion: 6,
+    parser: require('@typescript-eslint/parser')
+  }
 });
 
 function unusedFieldsWarning(field) {


### PR DESCRIPTION
This PR addresses some CI/CD pipeline issues:

- Upgrades `actions/checkout` to v4
- Upgrades `actions/setup-node` to v4
- Pins Yarn to v1 to prevent automatic upgrades to Yarn 2
- Resolves Prettier formatting issues that were causing pipeline failures