### PR TITLE
colocate: ignore empty module names

### DIFF
--- a/src/rule-must-colocate-fragment-spreads.js
+++ b/src/rule-must-colocate-fragment-spreads.js
@@ -134,8 +134,8 @@ module.exports = {
         graphqlLiterals.forEach(({node, graphQLAst}) => {
           const queriedFragments = getGraphQLFragmentSpreads(graphQLAst);
           for (const fragment in queriedFragments) {
-            const matchedModuleName = foundImportedModules.find(name =>
-              fragment.startsWith(name)
+            const matchedModuleName = foundImportedModules.find(
+              name => name && fragment.startsWith(name)
             );
             if (
               !matchedModuleName &&

--- a/test/must-colocate-fragment-spreads.js
+++ b/test/must-colocate-fragment-spreads.js
@@ -108,6 +108,14 @@ ruleTester.run(
         # eslint-disable-next-line relay/must-colocate-fragment-spreads
         ...unused1
       }\`;
+      `,
+      `
+      import { foo } from '../';
+      import { Component } from '../shared/component.js';
+      console.log(foo);
+      graphql\`fragment foo on Page {
+        ...component_fragment
+      }\`;
       `
     ],
     invalid: [


### PR DESCRIPTION
When extracting module names with utils::getModuleName, any explicit or implicit import of an 'index' file in a module's directory or one of its parents resolves to an empty string. Since all JS strings begin with an empty string, this is considered a matching module name for a used fragment spread. Subsequent imports are ignored because a module name matches. However, the falsiness of the empty string causes an error to still be reported.

In pathological cases, an empty module name can be imported _before_ the import that correctly matches a used fragment spread. This resulted in a false-positive "must be colocated" error, despite the fact that the required import is in fact present.

Ignore empty module names when looking for imports that satisfy a fragment spread's colocation requirement.