### PR TITLE
ci: bump actions/checkout to v7 and actions/setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         node-version: [22.x, 24.x]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -29,8 +29,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: 'yarn'
@@ -47,8 +47,8 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'relayjs/eslint-plugin-relay'
     needs: [build, lint]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` from v4 to v7 and `actions/setup-node` from v4 to v6.
- Both new majors ship on the Node 24 runtime, clearing the Node 20 deprecation warnings GitHub is now emitting for v4-pinned actions.

## Test plan
- [ ] CI passes on this PR (build + lint on Node 22.x and 24.x).
- [ ] No "Node.js 20 is deprecated" annotations appear on the run.